### PR TITLE
Feature: Implement service categories entity

### DIFF
--- a/backend/src/controllers/service-categories.controller.ts
+++ b/backend/src/controllers/service-categories.controller.ts
@@ -1,0 +1,54 @@
+import { Controller, Get, Post, Body, Param, Delete, ValidationPipe, UsePipes, HttpStatus, HttpCode } from '@nestjs/common';
+import { ServiceCategoryService } from '@/services/service-categories.service';
+import { CreateServiceCategoryDto, ServiceCategoryDto } from '@/dtos/service-categories.dto';
+
+@Controller('service-categories')
+export class ServiceCategoryController {
+  constructor(private readonly serviceCategoryService: ServiceCategoryService) {}
+
+  @Post()
+  @UsePipes(new ValidationPipe())
+  async create(@Body() createServiceCategoryDto: CreateServiceCategoryDto): Promise<ServiceCategoryDto> {
+    const result = await this.serviceCategoryService.create(createServiceCategoryDto);
+    return {
+      service_id: result.service_id,
+      category_id: result.category_id
+    };
+  }
+
+  @Get()
+  async findAll(): Promise<ServiceCategoryDto[]> {
+    const results = await this.serviceCategoryService.findAll();
+    return results.map(item => ({
+      service_id: item.service_id,
+      category_id: item.category_id
+    }));
+  }
+
+  @Get('service/:serviceId')
+  async findByServiceId(@Param('serviceId') serviceId: string): Promise<ServiceCategoryDto[]> {
+    const results = await this.serviceCategoryService.findByServiceId(serviceId);
+    return results.map(item => ({
+      service_id: item.service_id,
+      category_id: item.category_id
+    }));
+  }
+
+  @Get('category/:categoryId')
+  async findByCategoryId(@Param('categoryId') categoryId: string): Promise<ServiceCategoryDto[]> {
+    const results = await this.serviceCategoryService.findByCategoryId(categoryId);
+    return results.map(item => ({
+      service_id: item.service_id,
+      category_id: item.category_id
+    }));
+  }
+
+  @Delete(':serviceId/:categoryId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(
+    @Param('serviceId') serviceId: string,
+    @Param('categoryId') categoryId: string
+  ): Promise<void> {
+    await this.serviceCategoryService.remove(serviceId, categoryId);
+  }
+}

--- a/backend/src/dtos/service-categories.dto.ts
+++ b/backend/src/dtos/service-categories.dto.ts
@@ -1,0 +1,16 @@
+import { IsUUID, IsNotEmpty } from 'class-validator';
+
+export class CreateServiceCategoryDto {
+  @IsNotEmpty()
+  @IsUUID()
+  service_id: string;
+
+  @IsNotEmpty()
+  @IsUUID()
+  category_id: string;
+}
+
+export class ServiceCategoryDto {
+  service_id: string;
+  category_id: string;
+}

--- a/backend/src/entities/service-categories.entity.ts
+++ b/backend/src/entities/service-categories.entity.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryColumn } from 'typeorm';
+
+@Entity('service_categories')
+export class ServiceCategory {
+  @PrimaryColumn('uuid')
+  service_id: string;
+
+  @PrimaryColumn('uuid')
+  category_id: string;
+}

--- a/backend/src/repositories/service-categories.repository.ts
+++ b/backend/src/repositories/service-categories.repository.ts
@@ -1,0 +1,18 @@
+import { EntityRepository, Repository } from 'typeorm';
+import { ServiceCategory } from '@/entities/service-categories.entity';
+
+@EntityRepository(ServiceCategory)
+export class ServiceCategoryRepository extends Repository<ServiceCategory> {
+  async findByServiceId(serviceId: string): Promise<ServiceCategory[]> {
+    return this.find({ where: { service_id: serviceId } });
+  }
+
+  async findByCategoryId(categoryId: string): Promise<ServiceCategory[]> {
+    return this.find({ where: { category_id: categoryId } });
+  }
+
+  async findByServiceAndCategory(serviceId: string, categoryId: string): Promise<ServiceCategory | undefined> {
+    const result = await this.findOne({ where: { service_id: serviceId, category_id: categoryId } });
+    return result || undefined;
+  }
+}

--- a/backend/src/services/service-categories.service.ts
+++ b/backend/src/services/service-categories.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ServiceCategoryRepository } from '@/repositories/service-categories.repository';
+import { ServiceCategory } from '@/entities/service-categories.entity';
+import { CreateServiceCategoryDto } from '@/dtos/service-categories.dto';
+
+@Injectable()
+export class ServiceCategoryService {
+  constructor(
+    @InjectRepository(ServiceCategoryRepository)
+    private serviceCategoryRepository: ServiceCategoryRepository,
+  ) {}
+
+  async create(createServiceCategoryDto: CreateServiceCategoryDto): Promise<ServiceCategory> {
+    const serviceCategory = new ServiceCategory();
+    serviceCategory.service_id = createServiceCategoryDto.service_id;
+    serviceCategory.category_id = createServiceCategoryDto.category_id;
+    
+    return this.serviceCategoryRepository.save(serviceCategory);
+  }
+
+  async findAll(): Promise<ServiceCategory[]> {
+    return this.serviceCategoryRepository.find();
+  }
+
+  async findByServiceId(serviceId: string): Promise<ServiceCategory[]> {
+    return this.serviceCategoryRepository.findByServiceId(serviceId);
+  }
+
+  async findByCategoryId(categoryId: string): Promise<ServiceCategory[]> {
+    return this.serviceCategoryRepository.findByCategoryId(categoryId);
+  }
+
+  async remove(serviceId: string, categoryId: string): Promise<void> {
+    await this.serviceCategoryRepository.delete({ service_id: serviceId, category_id: categoryId });
+  }
+}


### PR DESCRIPTION
# 📝 Pull Request Title
feat: Implement service-categories entity

## 🛠️ Issue
Closes #31

## 📚 Description
The service-categories entity must be implemented in the backend, including its base structure with DTOs, Service, Repository, Entity, and Controller.

### 📌 General Rules:
- ✅ If the folder does not exist, create it exactly as specified.
- ✅ Use alias `@/` for imports.
- ✅ Use kebab-case for filenames.

### 📂 Folder and File Structure
**Main Directory:** `/backend/src/`

Created service-categories.entity.ts in @/entities/.

Created service-categories.dto.ts in @/dtos/.

Created service-categories.repository.ts in @/repositories/.

Created service-categories.service.ts in @/services/.

Created service-categories.controller.ts in @/controllers/.