### PR TITLE
feat: create-help-page

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,6 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
-  }
+  },
+  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
 }

--- a/src/app/help-page/page.tsx
+++ b/src/app/help-page/page.tsx
@@ -1,0 +1,17 @@
+import HelpHeader from "../../pages/help-page/components/help-header"
+import HelpCategoryCards from "../../pages/help-page/components/help-category-cards"
+import HelpTopicsTabs from "@/pages/help-page/components/help-topics-taps"
+import ContactSupport from "@/pages/help-page/components/contact-support"
+import CommunityResources from "@/pages/help-page/components/community-resources"
+export default function HelpPage() {
+    return (
+        <>
+        <HelpHeader />
+        <HelpCategoryCards />
+        <HelpTopicsTabs />
+        <ContactSupport />
+        <CommunityResources />
+      </>
+    )
+  }
+  

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+
+export default function Home() {
+  return (
+    <div>
+           <h1></h1>
+        </div>
+  );
+
+}

--- a/src/pages/help-page/components/community-resources.tsx
+++ b/src/pages/help-page/components/community-resources.tsx
@@ -1,0 +1,61 @@
+
+
+import Image from "next/image";
+import { FiExternalLink } from "react-icons/fi";
+
+const resources = [
+  {
+    title: "Community Forum",
+    description:
+      "Connect with other freelancers and clients, share experiences, and get advice from the Offer Hub community.",
+    href: "#",
+    image: "/community-placeholder.png", 
+  },
+  {
+    title: "Freelancer Blog",
+    description:
+      "Read articles, tips, and success stories to help you grow your freelance business or find the perfect talent.",
+    href: "#",
+    image: "/blog-placeholder.png",
+    external: true,
+  },
+];
+
+export default function CommunityResources() {
+  return (
+    <section className="max-w-6xl mx-auto px-4 py-16">
+      <h2 className="text-2xl font-bold text-center mb-2">Community & Resources</h2>
+      <p className="text-center text-gray-600 mb-10">
+        Join our <a href="#" className="text-teal-600 font-medium hover:underline">community</a> and access additional resources to enhance your experience
+      </p>
+
+      <div className="grid sm:grid-cols-2 gap-6">
+        {resources.map((res, idx) => (
+          <a
+            key={idx}
+            href={res.href}
+            target={res.external ? "_blank" : "_self"}
+            rel="noopener noreferrer"
+            className="block bg-white border rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow"
+          >
+            <div className="relative w-full h-40 bg-gray-100">
+              <Image
+                src={res.image}
+                alt={res.title}
+                fill
+                className="object-cover"
+              />
+            </div>
+            <div className="p-4">
+              <h3 className="font-semibold text-gray-900 flex items-center gap-1">
+                {res.title}
+                {res.external && <FiExternalLink className="text-sm" />}
+              </h3>
+              <p className="text-sm text-gray-600 mt-1">{res.description}</p>
+            </div>
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/help-page/components/contact-support.tsx
+++ b/src/pages/help-page/components/contact-support.tsx
@@ -1,0 +1,63 @@
+
+import { MdEmail, MdPhone, MdChat } from "react-icons/md";
+
+const supportOptions = [
+  {
+    icon: <MdEmail className="text-teal-600 text-3xl" />,
+    title: "Email Support",
+    description: "Get help via email with a response time of 24–48 hours.",
+    buttonLabel: "Email Us",
+    buttonStyle: "bg-teal-600 text-white hover:bg-teal-700",
+    href: "#",
+  },
+  {
+    icon: <MdChat className="text-teal-600 text-3xl" />,
+    title: "Live Chat",
+    description: "Chat with our support team during business hours.",
+    buttonLabel: "Start Chat",
+    buttonStyle: "border border-teal-600 text-teal-600 hover:bg-teal-50",
+    href: "#",
+  },
+  {
+    icon: <MdPhone className="text-teal-600 text-3xl" />,
+    title: "Phone Support",
+    description: "Call us directly for urgent matters and premium support.",
+    buttonLabel: "Call Support",
+    buttonStyle: "border border-teal-600 text-teal-600 hover:bg-teal-50",
+    href: "#",
+  },
+];
+
+export default function ContactSupport() {
+  return (
+    <section className="bg-gray-50 py-16 px-4">
+      <div className="max-w-6xl mx-auto text-center">
+        <h2 className="text-2xl font-bold mb-2">Contact Support</h2>
+        <p className="text-gray-600 mb-10">
+          Can’t find what you’re looking for? Our support team is here to help.
+        </p>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 text-left">
+          {supportOptions.map((option, idx) => (
+            <div
+              key={idx}
+              className="bg-white border rounded-lg p-6 flex flex-col items-start shadow-sm hover:shadow-md transition-shadow"
+            >
+              <div className="bg-teal-50 p-3 rounded-full mb-4">
+                {option.icon}
+              </div>
+              <h3 className="font-semibold text-lg text-gray-900 mb-1">{option.title}</h3>
+              <p className="text-sm text-gray-600 mb-4">{option.description}</p>
+              <a
+                href={option.href}
+                className={`text-sm font-medium px-4 py-2 rounded-md transition-colors ${option.buttonStyle}`}
+              >
+                {option.buttonLabel}
+              </a>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/help-page/components/help-category-cards.tsx
+++ b/src/pages/help-page/components/help-category-cards.tsx
@@ -1,0 +1,51 @@
+
+
+import { MdMenuBook, MdLiveHelp, MdSmartDisplay } from "react-icons/md";
+import Link from "next/link";
+
+const categories = [
+  {
+    icon: <MdMenuBook className="text-teal-600 text-3xl" />,
+    title: "Browse FAQ",
+    description: "Find answers to the most common questions about using Offer Hub.",
+    linkText: "View FAQ",
+    linkHref: "#",
+  },
+  {
+    icon: <MdLiveHelp className="text-teal-600 text-3xl" />,
+    title: "Submit a Ticket",
+    description: "Need specific help? Submit a support ticket and we’ll get back to you.",
+    linkText: "Create Ticket",
+    linkHref: "#",
+  },
+  {
+    icon: <MdSmartDisplay className="text-teal-600 text-3xl" />,
+    title: "Video Tutorials",
+    description: "Watch step-by-step tutorials to learn how to use Offer Hub effectively.",
+    linkText: "Watch Tutorials",
+    linkHref: "#",
+  },
+];
+
+export default function HelpCategoryCards() {
+  return (
+    <div className="max-w-7xl mx-auto py-12 px-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      {categories.map((cat, idx) => (
+        <div
+          key={idx}
+          className="border rounded-lg p-6 bg-white shadow-sm hover:shadow-md transition-shadow"
+        >
+          <div className="mb-4 bg-teal-50 w-fit p-3 rounded-full">{cat.icon}</div>
+          <h3 className="text-lg font-semibold mb-1">{cat.title}</h3>
+          <p className="text-sm text-gray-600 mb-3">{cat.description}</p>
+          <Link
+            href={cat.linkHref}
+            className="text-sm text-teal-600 font-medium hover:underline"
+          >
+            {cat.linkText} →
+          </Link>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/help-page/components/help-header.tsx
+++ b/src/pages/help-page/components/help-header.tsx
@@ -1,0 +1,39 @@
+
+import Image from "next/image";
+import Link from "next/link";
+
+export default function HelpHeader() {
+  return (
+    <header className="bg-white shadow-sm">
+      <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-4">
+        <div className="flex items-center gap-2">
+          <Image src="/logo.svg" alt="Offer Hub Logo" width={32} height={32} />
+          <span className="text-sm font-semibold text-gray-900 tracking-wide">
+            OFFER HUB
+          </span>
+        </div>
+        <Link href="/" className="text-sm text-blue-700 hover:underline flex items-center gap-1">
+          <span className="text-lg">←</span>
+          Back to Home
+        </Link>
+      </div>
+
+      <div className="bg-gradient-to-r from-teal-900 to-teal-600 text-white py-16 px-4 text-center">
+        <h1 className="text-3xl font-bold mb-2">How Can We Help You?</h1>
+        <p className="text-lg mb-6">
+          Find answers, resources, and support to make the most of Offer Hub
+        </p>
+        <div className="max-w-xl mx-auto flex items-center bg-white rounded-md overflow-hidden">
+          <input
+            type="text"
+            placeholder="Search for help articles..."
+            className="flex-1 px-4 py-3 text-gray-700 placeholder-gray-500 outline-none"
+          />
+          <button className="bg-teal-700 text-white px-6 py-3 hover:bg-teal-800 transition-colors">
+            🔍 Search
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/pages/help-page/components/help-topics-taps.tsx
+++ b/src/pages/help-page/components/help-topics-taps.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useState } from 'react';
+
+const tabs = [
+  'Getting Started',
+  'Account & Profile',
+  'Projects & Payments',
+  'Troubleshooting',
+];
+
+const content: Record<
+  string,
+  { title: string; description: string; new?: boolean }[]
+> = {
+  'Getting Started': [
+    {
+      title: 'Creating Your Account',
+      description: 'Step-by-step guide on registering a new account.',
+    },
+    {
+      title: 'Building Your Profile',
+      description: 'Tips for creating a strong and trustworthy profile.',
+    },
+    {
+      title: 'Finding Your Project',
+      description: 'How to browse and find the right project for you.',
+    },
+    {
+      title: 'Posting Your First Job',
+      description: 'Guide to publishing your first job as a client.',
+      new: true,
+    },
+  ],
+  'Account & Profile': [
+    {
+      title: 'Managing Account Settings',
+      description: 'Update your personal details and preferences.',
+    },
+    {
+      title: 'Security Best Practices',
+      description: 'Protect your account with 2FA and other tips.',
+    },
+    {
+      title: 'Notification Settings',
+      description: 'Customize how and when you receive updates.',
+    },
+    {
+      title: 'Linking Social Accounts',
+      description: 'Connect Facebook, Google, and more to your profile.',
+      new: true,
+    },
+  ],
+  'Projects & Payments': [
+    {
+      title: 'Creating Milestones',
+      description: 'How to break down projects into manageable milestones.',
+    },
+    {
+      title: 'Payment Methods',
+      description: 'Overview of available payment options and how to set them up.',
+    },
+    {
+      title: 'Contracts & Agreements',
+      description: 'Understanding the legal aspects of freelance contracts.',
+    },
+    {
+      title: 'Dispute Resolution',
+      description: 'Steps to take if there’s a disagreement about a project.',
+      new: true,
+    },
+  ],
+  'Troubleshooting': [
+    {
+      title: 'Login Issues',
+      description: 'Recover your account and resolve sign-in problems.',
+    },
+    {
+      title: 'Payment Troubleshooting',
+      description: 'Fix errors and delays in payment processing.',
+    },
+    {
+      title: 'Communicating Problems',
+      description: 'What to do when messaging or calls aren’t working.',
+    },
+    {
+      title: 'Mobile App Troubleshooting',
+      description: 'Fix bugs and performance issues on the mobile app.',
+      new: true,
+    },
+  ],
+};
+
+export default function HelpTopicsTabs() {
+  const [activeTab, setActiveTab] = useState('Getting Started');
+
+  return (
+    <section className="max-w-6xl mx-auto px-4 py-12">
+      <h2 className="text-2xl font-bold text-center mb-2">Browse Help Topics</h2>
+      <p className="text-center text-gray-600 mb-6">
+        Explore our comprehensive guides and tutorials to get the most out of Offer Hub
+      </p>
+
+      <div className="flex flex-wrap justify-center gap-2 mb-8">
+        {tabs.map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`px-4 py-2 rounded-md font-medium transition-colors ${
+              tab === activeTab
+                ? 'bg-gray-300 text-gray-900'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            }`}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+
+      <div className="grid sm:grid-cols-2 gap-6">
+        {content[activeTab].map((item, idx) => (
+          <div
+            key={idx}
+            className="bg-white shadow-sm border rounded-lg p-4 hover:shadow-md transition-shadow"
+          >
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-gray-900">{item.title}</h3>
+              {item.new && (
+                <span className="bg-blue-100 text-blue-700 text-xs font-semibold px-2 py-0.5 rounded-full">
+                  New
+                </span>
+              )}
+            </div>
+            <p className="text-sm text-gray-600 mt-1 mb-2">{item.description}</p>
+            <a
+              href="#"
+              className="text-teal-600 text-sm font-medium hover:underline"
+            >
+              Read article →
+            </a>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
# 📝 CREATE HELP PAGE

## 🛠️ Issue 
- Closes #92 

## 📚 Description
This PR introduces the full Help Center UI for Offer Hub, replicating the layout seen in the design references. It includes the header, search bar, category navigation cards, topic tabs, support options, and community resources section.

## ✅ Changes applied
Added help-header.tsx — Page hero with logo, search input, and intro message

Added help-category-cards.tsx — 3 quick-access cards: FAQ, Submit Ticket, Video Tutorials

Added help-topics-tabs.tsx — Tabbed navigation for Help Topics, with 4 items per category

Added contact-support.tsx — Section with cards for email, chat, and phone support options

Added community-resources.tsx — Section with resources like Community Forum and Blog

Integrated all components into HelpPage at app/help-page/page.tsx

## 🔍 Evidence/Media (screenshots/videos)
![image](https://github.com/user-attachments/assets/2bf6f09d-3032-463c-8604-f8dfe623b7b7)

![image](https://github.com/user-attachments/assets/33733c10-6b79-4611-9293-20dd595cc8d6)

![image](https://github.com/user-attachments/assets/c2fa1e26-e699-449e-9f72-9108472c1ead)

![image](https://github.com/user-attachments/assets/b648740a-f3a4-48da-87e2-7ecb2274f37e)

![image](https://github.com/user-attachments/assets/d9fbcdfb-ff27-4409-abc1-b91298324617)

![image](https://github.com/user-attachments/assets/4150d0cc-7bf9-47a1-96a2-5cbd97ca7314)

![image](https://github.com/user-attachments/assets/23a996a3-c5a9-4e4b-a19d-23ea9179988f)
