### PR TITLE
add restrict-account-modal component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       react:
         specifier: ^19.0.0
         version: 19.0.0
+      react-day-picker:
+        specifier: ^9.6.7
+        version: 9.7.0(react@19.0.0)
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
@@ -114,8 +117,8 @@ importers:
         specifier: ^7.54.2
         version: 7.54.2(react@19.0.0)
       react-icons:
-        specifier: ^5.4.0
-        version: 5.4.0(react@19.0.0)
+        specifier: ^5.5.0
+        version: 5.5.0(react@19.0.0)
       react-tsparticles:
         specifier: ^2.12.2
         version: 2.12.2(react@19.0.0)
@@ -315,6 +318,9 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@date-fns/tz@1.2.0':
+    resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
 
   '@emnapi/runtime@1.3.1':
     resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
@@ -1862,6 +1868,12 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  date-fns-jalali@4.1.0-0:
+    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
   dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
 
@@ -3018,6 +3030,12 @@ packages:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
 
+  react-day-picker@9.7.0:
+    resolution: {integrity: sha512-urlK4C9XJZVpQ81tmVgd2O7lZ0VQldZeHzNejbwLWZSkzHH498KnArT0EHNfKBOWwKc935iMLGZdxXPRISzUxQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8.0'
+
   react-dom@19.0.0:
     resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
@@ -3029,8 +3047,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
-  react-icons@5.4.0:
-    resolution: {integrity: sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==}
+  react-icons@5.5.0:
+    resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
     peerDependencies:
       react: '*'
 
@@ -4022,6 +4040,8 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
     optional: true
+
+  '@date-fns/tz@1.2.0': {}
 
   '@emnapi/runtime@1.3.1':
     dependencies:
@@ -5563,6 +5583,10 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  date-fns-jalali@4.1.0-0: {}
+
+  date-fns@4.1.0: {}
+
   dayjs@1.11.13: {}
 
   debug@2.6.9:
@@ -6835,6 +6859,13 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
+  react-day-picker@9.7.0(react@19.0.0):
+    dependencies:
+      '@date-fns/tz': 1.2.0
+      date-fns: 4.1.0
+      date-fns-jalali: 4.1.0-0
+      react: 19.0.0
+
   react-dom@19.0.0(react@19.0.0):
     dependencies:
       react: 19.0.0
@@ -6844,7 +6875,7 @@ snapshots:
     dependencies:
       react: 19.0.0
 
-  react-icons@5.4.0(react@19.0.0):
+  react-icons@5.5.0(react@19.0.0):
     dependencies:
       react: 19.0.0
 

--- a/src/components/modals/RestrictAccountModal.tsx
+++ b/src/components/modals/RestrictAccountModal.tsx
@@ -1,0 +1,117 @@
+"use client"
+import * as React from "react";
+import {
+  Bold,
+  FileText,
+  Link2 as Link,
+  Video,
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
+  Code2,
+  Eye,
+  ChevronDown,
+  X
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Separator } from "@/components/ui/separator";
+import { Dialog, DialogContent, DialogTitle, DialogClose } from "@/components/ui/dialog";
+
+const DEFAULT_WARNING_MESSAGE = `Hi [Customer name]
+
+We noticed some unacceptable activities with your account which are against our terms of service. So your account has been restricted for 30 days. Please review our guidelines to ensure compliance.
+
+If such activities persist it will lead to permanent restriction of your account
+
+XYZ team`;
+
+function RestrictAccountModal() {
+  return (
+    <Dialog open={true}>
+      <DialogContent className="sm:max-w-[500px]">
+        <div className="flex justify-between items-center">
+          <DialogTitle className="font-normal">Restrict account</DialogTitle>
+          <DialogClose className="h-4 w-4 opacity-70 transition-opacity hover:opacity-100" />
+        </div>
+
+        <div className="mt-4">
+          {/* Toolbar */}
+          <div className="flex items-center border rounded-md p-1 mb-2">
+            <div className="flex items-center border rounded px-1 py-0.5 hover:bg-slate-100 cursor-pointer mr-1">
+              <span className="text-xs mr-1 text-gray-500">14px</span>
+              <ChevronDown className="h-3 w-3 text-gray-500" />
+            </div>
+
+            {/* Text formatting */}
+            <Button variant="ghost" size="sm" className="h-8 w-8 p-1 hover:bg-slate-100">
+              <Bold className="h-4 w-4 text-gray-500" />
+            </Button>
+            <Button variant="ghost" size="sm" className="h-8 w-8 p-1 hover:bg-slate-100 flex items-center gap-0.5">
+              <span className="text-gray-500 font-medium">A</span>
+              <ChevronDown className="h-3 w-3 text-gray-500" />
+            </Button>
+            <Button variant="ghost" size="sm" className="h-8 w-8 p-1 hover:bg-slate-100">
+              <FileText className="h-4 w-4 text-gray-500" />
+            </Button>
+            <Button variant="ghost" size="sm" className="h-8 w-8 p-1 hover:bg-slate-100">
+              <Link className="h-4 w-4 text-gray-500" />
+            </Button>
+            <Button variant="ghost" size="sm" className="h-8 w-8 p-1 hover:bg-slate-100">
+              <Video className="h-4 w-4 text-gray-500" />
+            </Button>
+
+            <Separator orientation="vertical" className="mx-1 h-6" />
+
+            {/* Alignment */}
+            <Button variant="ghost" size="sm" className="h-8 w-8 p-2 hover:bg-slate-100">
+              <AlignLeft className="h-4 w-4 text-gray-500" />
+            </Button>
+            <Button variant="ghost" size="sm" className="h-8 w-8 p-2 hover:bg-slate-100">
+              <AlignCenter className="h-4 w-4 text-gray-500" />
+            </Button>
+            <Button variant="ghost" size="sm" className="h-8 w-8 p-2 hover:bg-slate-100">
+              <AlignRight className="h-4 w-4 text-gray-500" />
+            </Button>
+
+            <Separator orientation="vertical" className="mx-1 h-6" />
+
+            {/* Code and Preview */}
+            <Button variant="ghost" size="sm" className="h-8 w-8 p-2 hover:bg-slate-100">
+              <Code2 className="h-4 w-4 text-gray-500" />
+            </Button>
+            <Button variant="ghost" size="sm" className="h-8 w-8 p-2 hover:bg-slate-100">
+              <Eye className="h-4 w-4 text-gray-500" />
+            </Button>
+          </div>
+
+          {/* Text area */}
+          <Textarea 
+            value={DEFAULT_WARNING_MESSAGE}
+            className="min-h-[200px] resize-none font-normal"
+            readOnly
+          />
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 mt-4">
+          <Button 
+            variant="outline" 
+
+            className="rounded-full"
+          >
+            Cancel
+          </Button>
+          <Button 
+            variant="destructive" 
+            className="rounded-full"
+          >
+            Restrict Account
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default RestrictAccountModal;


### PR DESCRIPTION
# 📝 Pull Request Title
add restrict-account-modal component
## 🛠️ Issue
feat: RestrictAccountModal #165
- Closes #issue-ID
#165
## 📚 Description
  -Add restrict-account-modal component


## ✅ Changes applied

-RestrictAccountModal.tsx component created inside components/modals/ or similar folder
-Modal layout matches the provided mockup
-Text area supports multiline input with the default warning message
-Buttons are visually correct but non-functional
-Component is isolated (always visible for now)
-Ready for future wiring via a “Restrict Account” button elsewhere

## 🔍 Evidence/Media (screenshots/videos)

-
![Screenshot (77)](https://github.com/user-attachments/assets/6268424b-43b3-41e2-8b1d-c89b8b569a2d)

