### PR TITLE
feat(dispute-resolution): implement active dispute chat view with conflict modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@faker-js/faker": "^9.8.0",
     "@hookform/resolvers": "^3.10.0",
     "@nestjs/common": "^11.0.10",
     "@nestjs/core": "^11.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@creit.tech/stellar-wallets-kit':
-        specifier: ^1.6.1
-        version: 1.7.5(@stellar/stellar-base@13.1.0)(@stellar/stellar-sdk@12.3.0)(@trezor/connect@9.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@types/react@19.0.6)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(near-api-js@5.1.1)(react@19.0.0)(tslib@2.8.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@hookform/resolvers':
         specifier: ^3.10.0
         version: 3.10.0(react-hook-form@7.54.2(react@19.0.0))
@@ -392,28 +389,6 @@ packages:
   '@eslint/plugin-kit@0.2.5':
     resolution: {integrity: sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@ethereumjs/common@4.4.0':
-    resolution: {integrity: sha512-Fy5hMqF6GsE6DpYTyqdDIJPJgUtDn4dL120zKw+Pswuo+iLyBsEYuSyzMw6NVzD2vDzcBG9fE4+qX4X2bPc97w==}
-
-  '@ethereumjs/rlp@5.0.2':
-    resolution: {integrity: sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  '@ethereumjs/tx@5.4.0':
-    resolution: {integrity: sha512-SCHnK7m/AouZ7nyoR0MEXw1OO/tQojSbp88t8oxhwes5iZkZCtfFdUrJaiIb72qIpH2FVw6s1k1uP7LXuH7PsA==}
-    engines: {node: '>=18'}
-
-  '@ethereumjs/util@9.1.0':
-    resolution: {integrity: sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==}
-    engines: {node: '>=18'}
-
-  '@everstake/wallet-sdk-solana@2.0.5':
-    resolution: {integrity: sha512-U5v5+wqkDyqENvKjAVMBNDSXhU7uNVxg1+p6HoWtdtsXBlsIKGpEywrKv3WkQItHmzTgqeix8csMMEB508cCww==}
-
-  '@fivebinaries/coin-selection@3.0.0':
-    resolution: {integrity: sha512-h25Pn1ZA7oqQBQDodGAgIsQt66T2wDge9onBKNqE66WNWL0KJiKJbpij8YOLo5AAlEIg5IS7EB1QjBgDOIg6DQ==}
 
   '@floating-ui/core@1.6.9':
     resolution: {integrity: sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==}
@@ -5920,40 +5895,6 @@ snapshots:
     dependencies:
       '@eslint/core': 0.10.0
       levn: 0.4.1
-
-  '@ethereumjs/common@4.4.0':
-    dependencies:
-      '@ethereumjs/util': 9.1.0
-
-  '@ethereumjs/rlp@5.0.2': {}
-
-  '@ethereumjs/tx@5.4.0':
-    dependencies:
-      '@ethereumjs/common': 4.4.0
-      '@ethereumjs/rlp': 5.0.2
-      '@ethereumjs/util': 9.1.0
-      ethereum-cryptography: 2.2.1
-
-  '@ethereumjs/util@9.1.0':
-    dependencies:
-      '@ethereumjs/rlp': 5.0.2
-      ethereum-cryptography: 2.2.1
-
-  '@everstake/wallet-sdk-solana@2.0.5(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana-program/compute-budget': 0.6.1(@solana/web3.js@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/stake': 0.1.0(@solana/web3.js@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/system': 0.6.2(@solana/web3.js@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana/web3.js': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - typescript
-      - ws
-
-  '@fivebinaries/coin-selection@3.0.0':
-    dependencies:
-      '@emurgo/cardano-serialization-lib-browser': 13.2.1
-      '@emurgo/cardano-serialization-lib-nodejs': 13.2.0
 
   '@floating-ui/core@1.6.9':
     dependencies:

--- a/src/app/admin/dispute-resolution/[id]/chat/page.tsx
+++ b/src/app/admin/dispute-resolution/[id]/chat/page.tsx
@@ -1,0 +1,47 @@
+'use client'
+import { useMessages } from "@/hooks/useMessages";
+import { MessagesSidebar } from "@/components/messages/messages-sidebar";
+import { MessagesMain } from "@/components/messages/messages-main";
+import { useRouter } from "next/router";
+import { Button } from "@/components/ui/button";
+import { MdGavel } from "react-icons/md";
+import { useState } from "react";
+import CloseConflictModal from "@/components/dispute-resolution/close-conflict-modal";
+
+
+export default function DisputeChat() {
+  const {
+    conversations,
+    activeConversationId,
+    setActiveConversationId,
+    activeConversation,
+    messages,
+    handleSendMessage,
+  } = useMessages();
+
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const handleOpenModal = () => setModalOpen(true);
+  const handleCloseModal = () => setModalOpen(false);
+  const handleConfirm = () => {
+    setModalOpen(false);
+  };
+
+  const closeDisputeButton = (
+    <Button className="bg-secondary-500 py-5 text-white rounded-full" onClick={handleOpenModal}>
+      <MdGavel /> Close conflict
+    </Button>
+  );
+
+  return (
+    <div className="flex h-full w-full lg:w-[714px] mx-auto bg-white rounded-md">
+      <MessagesMain
+        activeConversation={activeConversation}
+        messages={messages}
+        onSendMessage={handleSendMessage}
+        chatHeaderItem={closeDisputeButton}
+      />
+      <CloseConflictModal open={modalOpen} onClose={handleCloseModal} onConfirm={handleConfirm} />
+    </div>
+  );
+}

--- a/src/app/admin/dispute-resolution/layout.tsx
+++ b/src/app/admin/dispute-resolution/layout.tsx
@@ -1,0 +1,8 @@
+'use client'
+import type { ReactNode  } from "react";
+
+export default function DisputeResolutionLayout({ children }: { children: ReactNode }) {
+  return <div className="min-h-screen bg-white pt-5">
+      {children}
+  </div>;
+} 

--- a/src/app/admin/dispute-resolution/page.tsx
+++ b/src/app/admin/dispute-resolution/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+import React, { useState } from "react";
+import DisputeTabs from "@/components/dispute-resolution/tabs";
+import UnassignedDispute from "@/components/dispute-resolution/views/unassigned-dispute";
+import ResolvedDispute from "@/components/dispute-resolution/views/resolved-dispute";
+import ActiveDispute from "@/components/dispute-resolution/views/active-dispute";
+
+export default function DisputeResolutionPage() {
+
+
+  return (
+    <div className="p-6">
+      <DisputeTabs
+        defaultValue="unassigned"
+        tabs={[
+          {
+            label: "Unassigned dispute",
+            value: "unassigned",
+            component: <UnassignedDispute />,
+          },
+          {
+            label: "Active",
+            value: "active",
+            component: <ActiveDispute/>
+          },
+          {
+            label: "Resolved dispute",
+            value: "resolved",
+            component: <ResolvedDispute />,
+          },
+        ]}
+      />
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -6,7 +6,6 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-screen bg-white">
       <Sidebar />
-
       <div className="flex-1 flex flex-col overflow-auto">
         <Header />
         <main className="flex-1">{children}</main>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -41,9 +41,9 @@ export default function Sidebar({ onClose }: SidebarProps) {
     },
     {
       name: "Dispute resolution",
-      href: "/dispute-resolution",
+      href: "/admin/dispute-resolution",
       icon: FileText,
-      active: pathname.includes("/dispute-resolution"),
+      active: pathname.includes("/admin/dispute-resolution"),
     },
   ];
 

--- a/src/components/admin/components/NavItems.tsx
+++ b/src/components/admin/components/NavItems.tsx
@@ -1,11 +1,14 @@
+'use client'
 import type React from "react";
 import { cn } from "@/lib/utils";
+import { useRouter } from "next/navigation";
 
 interface NavItemProps {
   icon: React.ReactNode;
   label: string;
   active?: boolean;
   className?: string;
+  path: string
 }
 
 export default function NavItem({
@@ -13,7 +16,11 @@ export default function NavItem({
   label,
   active,
   className,
+  path = '/admin'
 }: NavItemProps) {
+
+  const { push } = useRouter()
+
   return (
     <div
       className={cn(
@@ -21,6 +28,7 @@ export default function NavItem({
         active && "bg-gray-100 text-gray-900",
         className
       )}
+      onClick={() => push(path)}
     >
       {icon}
       <span>{label}</span>

--- a/src/components/admin/layouts/Sidebar.tsx
+++ b/src/components/admin/layouts/Sidebar.tsx
@@ -1,8 +1,40 @@
-import { ArrowUpIcon, BarChart3Icon, BoxIcon, UsersIcon } from "lucide-react";
+'use client';
+
+import {
+  ArrowUpIcon,
+  BarChart3Icon,
+  BoxIcon,
+  UsersIcon,
+} from "lucide-react";
 import Image from "next/image";
+import { usePathname } from "next/navigation";
 import NavItem from "../components/NavItems";
 
+const navItems = [
+  {
+    path: "/admin",
+    icon: <BarChart3Icon className="h-5 w-5" />,
+    label: "Dashboard",
+  },
+  {
+    path: "/admin/user-management",
+    icon: <UsersIcon className="h-5 w-5" />,
+    label: "User management",
+  },
+  {
+    path: "/admin/platform-monitoring",
+    icon: <BarChart3Icon className="h-5 w-5" />,
+    label: "Platform monitoring",
+  },
+  {
+    path: "/admin/dispute-resolution",
+    icon: <BoxIcon className="h-5 w-5" />,
+    label: "Dispute resolution",
+  },
+];
+
 export default function Sidebar() {
+  const pathname = usePathname();
   return (
     <div className="w-64 border-r bg-gray-50">
       <div className="flex items-center gap-2 p-6">
@@ -11,23 +43,15 @@ export default function Sidebar() {
       </div>
 
       <nav className="space-y-1 px-3">
-        <NavItem
-          icon={<BarChart3Icon className="h-5 w-5" />}
-          label="Dashboard"
-          active
-        />
-        <NavItem
-          icon={<UsersIcon className="h-5 w-5" />}
-          label="User management"
-        />
-        <NavItem
-          icon={<BarChart3Icon className="h-5 w-5" />}
-          label="Platform monitoring"
-        />
-        <NavItem
-          icon={<BoxIcon className="h-5 w-5" />}
-          label="Dispute resolution"
-        />
+        {navItems.map((item) => (
+          <NavItem
+            key={item.label}
+            icon={item.icon}
+            label={item.label}
+            path={item.path}
+            active={pathname === item.path}
+          />
+        ))}
       </nav>
 
       <div className="absolute bottom-0 w-64 border-t p-3">
@@ -35,6 +59,7 @@ export default function Sidebar() {
           icon={<ArrowUpIcon className="h-5 w-5 rotate-90" />}
           label="Logout"
           className="text-red-500"
+          path="/logout"
         />
       </div>
     </div>

--- a/src/components/dispute-resolution/Tabs.tsx
+++ b/src/components/dispute-resolution/Tabs.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import PillTabs from "../tabs/pill-tabs";
+import { JSX } from "react";
+
+interface TabItem {
+  label: string;
+  value: string;
+  component: JSX.Element;
+}
+
+interface DisputeTabsProps {
+  tabs: TabItem[];
+  defaultValue?: string;
+  className?: string;
+}
+
+export default function DisputeTabs({ tabs, defaultValue = "unassigned", className }: DisputeTabsProps) {
+  return (
+    <PillTabs
+      tabs={tabs}
+      defaultValue={defaultValue}
+      className={className}
+    />
+  );
+}

--- a/src/components/dispute-resolution/close-conflict-modal.tsx
+++ b/src/components/dispute-resolution/close-conflict-modal.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+const recipients = ["John Doe", "Jane Smith", "Acme Corp"];
+
+export default function CloseConflictModal({ open, onClose, onConfirm }: { open: boolean; onClose: () => void; onConfirm: (recipient: string, message: string) => void }) {
+  const [recipient, setRecipient] = useState(recipients[0]);
+  const [message, setMessage] = useState(
+    `Hi [Customer name]\n\nWe have closed your conflict and released payment to you.\n\nXYZ team`
+  );
+
+  const handleConfirm = () => {
+    onConfirm(recipient, message);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-lg w-full">
+        <DialogHeader>
+          <DialogTitle className="text-md font-medium text-gray-600">Close conflict</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-6 mt-2">
+          <div className="flex flex-col lg:flex-row gap-3 items-center border p-3 border-gray-400/1 rounded-sm">
+            <label className="block text-sm font-medium mb-2">Release payment to</label>
+            <div className="border flex-1 rounded-md px-3 py-2 flex items-center focus-within:ring-2 focus-within:ring-primary-500">
+              <select
+                className="w-full bg-transparent outline-none text-base"
+                value={recipient}
+                onChange={e => setRecipient(e.target.value)}
+              >
+                {recipients.map((r) => (
+                  <option key={r} value={r}>{r}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div>
+            <label className="block text-base font-semibold mb-2">Message (Optional)</label>
+            <textarea
+              className="w-full border rounded-md px-3 py-2 min-h-[120px] text-base focus:outline-none focus:ring-2 focus:ring-primary-500"
+              value={message}
+              onChange={e => setMessage(e.target.value)}
+            />
+          </div>
+        </div>
+        
+        <DialogFooter className="flex flex-row justify-end gap-2 mt-6">
+          <DialogClose asChild>
+            <Button variant="outline" className="rounded-full px-6">Cancel</Button>
+          </DialogClose>
+          <Button onClick={handleConfirm} className="rounded-full px-6 bg-[#002333] hover:bg-[#002333]/90 text-white">
+            Close conflict
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+} 

--- a/src/components/dispute-resolution/disput-chat.tsx
+++ b/src/components/dispute-resolution/disput-chat.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { MessageBubble } from "@/components/chat/message-bubble";
+import { Button } from "@/components/ui/button";
+
+const mockMessages = [
+  {
+    id: 1,
+    content: "Hello, I have an issue with the payment.",
+    timestamp: "10:00 AM",
+    isOutgoing: false,
+    avatar: "/avatar_olivia.jpg",
+  },
+  {
+    id: 2,
+    content: "Can you provide more details?",
+    timestamp: "10:01 AM",
+    isOutgoing: true,
+  },
+];
+
+export default function DisputeChat({ onCloseConflict }: { onCloseConflict: () => void }) {
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 space-y-4 overflow-auto p-4 bg-gray-50 rounded-t-lg">
+        {mockMessages.map((msg) => (
+          <MessageBubble key={msg.id} {...msg} />
+        ))}
+      </div>
+      <div className="p-4 border-t bg-white flex justify-end">
+        <Button variant="destructive" onClick={onCloseConflict}>
+          Close conflict & release payment
+        </Button>
+      </div>
+    </div>
+  );
+} 

--- a/src/components/dispute-resolution/views/active-dispute.tsx
+++ b/src/components/dispute-resolution/views/active-dispute.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import FilterToolbar from "@/components/platform-monitoring/filter-toolbar";
+import DisputeTable, { DisputeTableColumn } from "@/components/table/DisputeTable";
+import { FaRegCopy } from "react-icons/fa";
+import { faker } from "@faker-js/faker";
+import Link from "next/link";
+
+interface DisputeRow {
+  date: string;
+  name: string;
+  ticket: string;
+  email: string;
+}
+
+const columns: DisputeTableColumn<DisputeRow>[] = [
+  { key: "date", label: "Date initiated" },
+  { key: "name", label: "Customer Name" },
+  {
+    key: "ticket",
+    label: "Ticket ID",
+    render: (row) => (
+      <span className="flex items-center gap-2 text-blue-600">
+        <span className="underline cursor-pointer">{row.ticket}</span>
+        <FaRegCopy className="w-4 h-4 cursor-pointer text-gray-400 hover:text-gray-600" />
+      </span>
+    ),
+  },
+  {
+    key: "email",
+    label: "Email address",
+    render: (row) =>
+      row.email.length > 25 ? row.email.slice(0, 25) + "..." : row.email,
+  },
+  {
+    key: "action",
+    label: "Action",
+    render: (row) => (
+      <Link
+        href={`/admin/dispute-resolution/${row.ticket}/chat`}
+        className="text-blue-500 hover:underline"
+      >
+        View dispute
+      </Link>
+    ),
+  },
+];
+
+const data: DisputeRow[] = Array.from({ length: 8 }).map(() => ({
+  date: faker.date
+    .recent()
+    .toLocaleString("en-GB", {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    })
+    .replace(",", " :"),
+  name: faker.person.fullName(),
+  ticket: faker.string.alphanumeric(9).toLowerCase(),
+  email: faker.internet.email(),
+}));
+
+export default function ActiveDispute() {
+  return (
+    <div className="space-y-4">
+      <FilterToolbar />
+      <DisputeTable columns={columns} data={data} />
+    </div>
+  );
+}

--- a/src/components/dispute-resolution/views/resolved-dispute.tsx
+++ b/src/components/dispute-resolution/views/resolved-dispute.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import FilterToolbar from "@/components/platform-monitoring/filter-toolbar";
+import DisputeTable, { DisputeTableColumn } from "@/components/table/DisputeTable";
+import { FaRegCopy } from "react-icons/fa";
+import { faker } from "@faker-js/faker";
+
+
+interface DisputeRow {
+  date: string;
+  name: string;
+  ticket: string;
+  email: string;
+}
+
+
+const columns: DisputeTableColumn<DisputeRow>[] = [
+  { key: "date", label: "Date initiated" },
+  { key: "name", label: "Customer Name" },
+  {
+    key: "ticket",
+    label: "Ticket ID",
+    render: (row) => (
+      <span className="flex items-center gap-2 text-blue-600">
+        <span className="underline cursor-pointer">{row.ticket}</span>
+        <FaRegCopy className="w-4 h-4 cursor-pointer text-gray-400 hover:text-gray-600" />
+      </span>
+    ),
+  },
+  {
+    key: "email",
+    label: "Email address",
+    render: (row) =>
+      row.email.length > 25 ? row.email.slice(0, 25) + "..." : row.email,
+  },
+  {
+    key: "action",
+    label: "Action",
+    render: () => (
+      <a href="#" className="text-blue-500 hover:underline">View dispute</a>
+    ),
+  },
+];
+
+
+const data: DisputeRow[] = Array.from({ length: 8 }).map(() => ({
+  date: faker.date
+    .recent()
+    .toLocaleString("en-GB", {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    })
+    .replace(",", " :"),
+  name: faker.person.fullName(),
+  ticket: faker.string.alphanumeric(9).toLowerCase(),
+  email: faker.internet.email(),
+}));
+
+
+export default function ResolvedDispute() {
+  return (
+    <div className="space-y-4">
+      <FilterToolbar />
+      <DisputeTable columns={columns} data={data} />
+    </div>
+  );
+}

--- a/src/components/dispute-resolution/views/unassigned-dispute.tsx
+++ b/src/components/dispute-resolution/views/unassigned-dispute.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import FilterToolbar from "@/components/platform-monitoring/filter-toolbar";
+import DisputeTable, { DisputeTableColumn } from "@/components/table/DisputeTable";
+import { FaRegCopy } from "react-icons/fa";
+import { faker } from "@faker-js/faker";
+import { DisputeRow } from "@/types";
+
+
+
+
+const columns: DisputeTableColumn<DisputeRow>[] = [
+  { key: "date", label: "Date initiated" },
+  { key: "name", label: "Customer Name" },
+  {
+    key: "ticket",
+    label: "Ticket ID",
+    render: (row) => (
+      <span className="flex items-center gap-2 text-blue-600">
+        <span className="underline cursor-pointer">{row.ticket}</span>
+        <FaRegCopy className="w-4 h-4 cursor-pointer text-gray-400 hover:text-gray-600" />
+      </span>
+    ),
+  },
+  {
+    key: "email",
+    label: "Email address",
+    render: (row) =>
+      row.email.length > 25 ? row.email.slice(0, 25) + "..." : row.email,
+  },
+  {
+    key: "action",
+    label: "Action",
+    render: () => (
+      <a href="#" className="text-blue-500 hover:underline">View dispute</a>
+    ),
+  },
+];
+
+
+const data: DisputeRow[] = Array.from({ length: 12 }).map(() => ({
+  date: faker.date
+    .recent()
+    .toLocaleString("en-GB", {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    })
+    .replace(",", " :"),
+  name: faker.person.fullName(), 
+  ticket: faker.string.alphanumeric(9).toLowerCase(),
+  email: faker.internet.email(),
+}));
+
+
+export default function UnassignedDispute() {
+  return (
+    <div className="space-y-4">
+      <FilterToolbar />
+      <DisputeTable columns={columns} data={data} />
+    </div>
+  );
+}

--- a/src/components/messages/messages-main.tsx
+++ b/src/components/messages/messages-main.tsx
@@ -10,7 +10,7 @@ import Icon from "../../../public/Icon.svg"
 import type { MessagesMainProps } from "@/types"
 import { useMessages } from "@/hooks/use-message"
 
-export function MessagesMain({ activeConversation, messages, onSendMessage }: MessagesMainProps) {
+export function MessagesMain({ activeConversation, messages, onSendMessage , chatHeaderItem }: MessagesMainProps) {
   const {
     newMessage,
     setNewMessage,
@@ -31,8 +31,10 @@ export function MessagesMain({ activeConversation, messages, onSendMessage }: Me
   return (
     <div className="flex-1 flex flex-col">
       <div className="p-4 px-16">
-        <div className="bg-[#DEEFE7] rounded-lg px-4 py-3 flex items-center gap-3">
-          <Avatar className="h-10 w-10">
+        <div className="bg-[#DEEFE7] rounded-lg px-4 py-3 flex items-center justify-between gap-3">
+
+            <div className="flex items-center gap-3">
+            <Avatar className="h-10 w-10">
             <AvatarImage src={maskGroup.src || "/placeholder.svg"} alt={activeConversation.name} />
             <AvatarFallback className="bg-gray-200 text-gray-600">
               {activeConversation.name
@@ -42,6 +44,11 @@ export function MessagesMain({ activeConversation, messages, onSendMessage }: Me
             </AvatarFallback>
           </Avatar>
           <h2 className="font-medium text-gray-900">{activeConversation.name}</h2>
+            </div>
+
+          <div>
+             {chatHeaderItem}
+          </div>
         </div>
       </div>
 

--- a/src/components/table/DisputeTable.tsx
+++ b/src/components/table/DisputeTable.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+export interface DisputeTableColumn {
+  key: string;
+  label: string;
+  render?: (row: any) => React.ReactNode;
+  className?: string;
+}
+
+export interface DisputeTableProps {
+  columns: DisputeTableColumn[];
+  data: any[];
+}
+
+const DisputeTable: React.FC<DisputeTableProps> = ({ columns, data }) => {
+  return (
+    <div className="overflow-x-auto mt-6">
+      <table className="min-w-full bg-white border border-gray-200 rounded-lg">
+        <thead>
+          <tr className="text-left  text-sm   border-b border-gray-200 bg-[#F9FAFB] ">
+            {columns.map((col) => (
+              <th key={col.key} className={`py-3 px-4 py-4 font-medium ${col.className || ""}`}>{col.label}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="text-gray-700 text-base">
+          {data.map((row, idx) => (
+            <tr key={idx} className="hover:bg-gray-50 transition">
+              {columns.map((col) => (
+                <td key={col.key} className={`py-3 text-sm px-4 whitespace-nowrap ${col.className || ""}`}>
+                  {col.render ? col.render(row) : row[col.key]}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default DisputeTable; 

--- a/src/components/tabs/pill-tabs.tsx
+++ b/src/components/tabs/pill-tabs.tsx
@@ -1,0 +1,32 @@
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import React from "react";
+import clsx from "clsx";
+import { PillTabsProps , TabItem } from "@/types";
+
+
+export default function PillTabs({ tabs, defaultValue, className }: PillTabsProps) {
+  return (
+    <Tabs defaultValue={defaultValue || tabs[0]?.value} className={className || "w-full"}>
+      <TabsList className="bg-transparent p-1 rounded-full inline-flex gap-2">
+        {tabs.map((tab) => (
+          <TabsTrigger
+            key={tab.value}
+            value={tab.value}
+            className={clsx(
+              "rounded-full px-4 py-2 text-sm font-medium transition-all",
+              "data-[state=active]:bg-[#002333] data-[state=active]:text-white",
+              "data-[state=inactive]:text-[#002333]"
+            )}
+          >
+            {tab.label}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+      {tabs.map((tab) => (
+        <TabsContent key={tab.value} value={tab.value}>
+          {tab.component}
+        </TabsContent>
+      ))}
+    </Tabs>
+  );
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import { JSX, ReactNode } from "react"
+
 export interface Message {
   id: number
   content: string
@@ -25,5 +27,27 @@ export interface Conversation {
 export interface MessagesMainProps {
   activeConversation?: Conversation
   messages: Message[]
+  chatHeaderItem?: JSX.Element
   onSendMessage: (content: string, file?: File) => void
+}
+
+
+export interface DisputeRow {
+  date: string;
+  name: string;
+  ticket: string;
+  email: string;
+}
+
+
+export interface TabItem {
+  label: string;
+  value: string;
+  component: ReactNode; 
+}
+
+export interface PillTabsProps {
+  tabs: TabItem[];
+  defaultValue?: string;
+  className?: string;
 }


### PR DESCRIPTION
# 📝 feat(dispute-resolution): implement active dispute chat view with conflict modal

## 🛠️ Issue

- Closes #issue-#201

## 📚 Description

- Integrated chat interface for active disputes
- Added modal to close conflicts and release payments
- Managed state for viewing specific disputes and modal visibility
- Ensured smooth tab switching and UI alignment with Figma design
- Created/Added a reusable Tab component called ```<PillTabs/>``` to match figma design

## ✅ Changes applied

- Created DisputeChat, CloseConflictModal, and ActiveDisputeTable components
- Reused MessageBubble for consistent chat styling
- Added state handling in DisputeResolutionPage.tsx for conditional rendering
- Built PillTabs.tsx for styled tab navigation with support for dynamic content
- Connected “View dispute” links to trigger specific chat views (using the dispute ID)

NB: The dummy items on the dispute-resolution route is being generated with [fakers.js](https://fakerjs.dev/) [Npm Link](https://www.npmjs.com/package/@faker-js/faker) 

## 🔍 Evidence/Media (screenshots/videos)

https://github.com/user-attachments/assets/11ac5180-e810-499c-a304-e0d68ad76b91
