### PR TITLE
Feat/password entry screen

### DIFF
--- a/src/app/(client)/onboarding/password/page.tsx
+++ b/src/app/(client)/onboarding/password/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Suspense } from "react";
+import { PasswordForm } from "@/components/auth/PasswordForm";
+import { AuthHeader } from "@/components/auth/AuthHeader";
+
+function PasswordPageContent() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <AuthHeader />
+      <div className="flex items-center justify-center p-4 pt-16">
+        <div className="w-full max-w-md">
+          <PasswordForm />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function PasswordPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <PasswordPageContent />
+    </Suspense>
+  );
+}

--- a/src/components/auth/AuthHeader.tsx
+++ b/src/components/auth/AuthHeader.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+
+export function AuthHeader() {
+  return (
+    <header className="w-full bg-white border-b border-gray-200 px-6 py-4">
+      <div className="max-w-7xl mx-auto flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <div className="w-8 h-8 rounded-full flex items-center justify-center">
+            <Image
+              src="/dark_logo.svg"
+              alt="Offer Hub"
+              width={30}
+              height={30}
+              className="text-white"
+            />
+          </div>
+          <span className="text-xl font-semibold text-gray-900">Offer Hub</span>
+        </div>
+
+        <Button
+          asChild
+          className="bg-slate-800 hover:bg-slate-900 text-white px-6 py-2 rounded-full text-sm font-medium"
+        >
+          <Link href="/onboarding/sign-up">Sign up</Link>
+        </Button>
+      </div>
+    </header>
+  );
+}

--- a/src/components/auth/PasswordForm.tsx
+++ b/src/components/auth/PasswordForm.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import type React from "react";
+
+import { useState } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { PasswordInput } from "./PasswordInput";
+import { RememberMeCheckbox } from "./RememberMeCheckbox";
+import Link from "next/link";
+
+export function PasswordForm() {
+  const [password, setPassword] = useState("");
+  const [keepLoggedIn, setKeepLoggedIn] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const email = searchParams.get("email") || "AdebayoDoe@yahoo.com";
+
+  const handleSignIn = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      console.log("Sign in attempt:", { email, password, keepLoggedIn });
+
+      router.push("/dashboard");
+    } catch (error) {
+      console.error("Sign in failed:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Card className="border-0 shadow-lg">
+      <CardContent className="p-8">
+        <div className="text-center mb-8">
+          <h1 className="text-2xl font-semibold text-gray-900 mb-2">
+            Welcome back
+          </h1>
+          <p className="text-sm text-gray-600">@{email}</p>
+        </div>
+
+        <form onSubmit={handleSignIn} className="space-y-6">
+          <PasswordInput
+            value={password}
+            onChange={setPassword}
+            disabled={isLoading}
+          />
+
+          <RememberMeCheckbox
+            checked={keepLoggedIn}
+            onChange={setKeepLoggedIn}
+            disabled={isLoading}
+          />
+
+          <div className="flex justify-center">
+            <Button
+              type="submit"
+              className="w-[20rem] bg-slate-800 hover:bg-slate-900 text-white py-2.5 rounded-full font-medium"
+              disabled={isLoading || !password}
+            >
+              {isLoading ? "Signing in..." : "Sign in"}
+            </Button>
+          </div>
+
+          <div className="text-center">
+            <Link
+              href="/onboarding/forgot-password"
+              className="text-sm text-red-500 hover:text-red-600 font-medium"
+            >
+              Forgot password?
+            </Link>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/auth/PasswordInput.tsx
+++ b/src/components/auth/PasswordInput.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+
+interface PasswordInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+export function PasswordInput({
+  value,
+  onChange,
+  disabled,
+}: PasswordInputProps) {
+  const [showPassword, setShowPassword] = useState(false);
+
+  const togglePasswordVisibility = () => {
+    setShowPassword(!showPassword);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor="password" className="text-sm font-medium text-gray-700">
+        Enter password
+      </Label>
+      <div className="relative">
+        <Input
+          id="password"
+          type={showPassword ? "text" : "password"}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          className="pr-12 py-3 border-gray-300 focus:border-slate-500 focus:ring-slate-500"
+          placeholder="••••••••"
+          required
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="absolute right-2 top-1/2 -translate-y-1/2 h-8 w-8 p-0 hover:bg-transparent"
+          onClick={togglePasswordVisibility}
+          disabled={disabled}
+        >
+          {showPassword ? (
+            <EyeOff className="h-4 w-4 text-gray-500" />
+          ) : (
+            <Eye className="h-4 w-4 text-gray-500" />
+          )}
+          <span className="sr-only">
+            {showPassword ? "Hide password" : "Show password"}
+          </span>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/RememberMeCheckbox.tsx
+++ b/src/components/auth/RememberMeCheckbox.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+
+interface RememberMeCheckboxProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+}
+
+export function RememberMeCheckbox({
+  checked,
+  onChange,
+  disabled,
+}: RememberMeCheckboxProps) {
+  return (
+    <div className="flex items-center space-x-2">
+      <Checkbox
+        id="keep-logged-in"
+        checked={checked}
+        onCheckedChange={onChange}
+        disabled={disabled}
+        className="border-gray-300 data-[state=checked]:bg-slate-800 data-[state=checked]:border-slate-800"
+      />
+      <Label
+        htmlFor="keep-logged-in"
+        className="text-sm text-gray-700 font-normal cursor-pointer"
+      >
+        Keep me logged in
+      </Label>
+    </div>
+  );
+}


### PR DESCRIPTION
# Pull Request Title

**feat: Implement password entry screen with header component for onboarding flow**

## ️ Issue 

- Closes #206 

## Description

Implemented the second step of the sign-in onboarding flow - the password entry screen. This includes a clean, responsive UI that matches the HiFi Figma design specifications, complete with password visibility toggle, "Keep me logged in" functionality, and proper navigation flow.

## Changes applied

- Created password entry page at `/onboarding/sign-in/password`
- Implemented modular auth components (`PasswordForm`, `PasswordInput`, `RememberMeCheckbox`)
- Added responsive header component with Offer Hub branding and sign-up CTA
- Integrated password visibility toggle with eye/eye-off icons
- Added form validation and loading states
- Implemented mock authentication flow with proper error handling
- Created forgot password placeholder page with navigation
- Applied consistent styling with fully rounded buttons matching design specs


## Evidence/Media (screenshots/videos)

https://github.com/user-attachments/assets/42638505-16f8-4328-b6a2-8209829ff6b1

- ✅ Password entry screen with welcome message and email display
- ✅ Functional password input with visibility toggle
- ✅ "Keep me logged in" checkbox component
- ✅ Responsive header with logo and sign-up button
- ✅ Fully rounded button styling matching Figma design
- ✅ Proper form validation and loading states
- ✅ Mobile-responsive layout