### PR TITLE
feat: implement dashboard layout and sidebar with navigation

### DIFF
--- a/src/app/(client)/onboarding/dashboard/layout.tsx
+++ b/src/app/(client)/onboarding/dashboard/layout.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { AuthHeader } from "@/components/auth/AuthHeader";
+import { ClientSidebar } from "@/components/client-dashboard/Sidebar";
+import { ReactNode } from "react";
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-col min-h-screen bg-gray-50">
+      <div className="w-full border-b border-gray-200 bg-white relative z-10">
+        <AuthHeader />
+      </div>
+      <div className="flex flex-1 min-h-0">
+        <div className="w-64 border-r border-gray-200 bg-white flex flex-col justify-between">
+          <ClientSidebar />
+        </div>
+        <div className="flex-1 px-6 py-4 overflow-y-auto">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(client)/onboarding/dashboard/page.tsx
+++ b/src/app/(client)/onboarding/dashboard/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { DashboardEmptyState } from "@/components/client-dashboard/DashboardEmptyState.tsx";
+import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
+import { useState } from "react";
+
+export default function DashboardPage() {
+  const [hasJobsOrContracts] = useState(false);
+
+  return (
+    <>
+      <div className="w-full border-b border-gray-200 bg-white py-3 text-center mb-6">
+        <h1 className="text-sm font-semibold text-gray-800">Dashboard</h1>
+      </div>
+
+      <div className="flex justify-between items-center mb-6">
+        <h2 className="text-xl font-medium text-gray-800">
+          Good Morning John Doe
+        </h2>
+        <Button className="bg-teal-600 hover:bg-teal-700 text-white">
+          <Plus className="w-4 h-4 mr-2" />
+          Post Job
+        </Button>
+      </div>
+
+      {hasJobsOrContracts ? (
+        <div className="p-6 rounded-md bg-white shadow-sm">
+          <p>Dashboard content with jobs/contracts would go here</p>
+        </div>
+      ) : (
+        <DashboardEmptyState />
+      )}
+    </>
+  );
+}

--- a/src/components/client-dashboard/DashboardEmptyState.tsx.tsx
+++ b/src/components/client-dashboard/DashboardEmptyState.tsx.tsx
@@ -1,0 +1,23 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Plus } from "lucide-react";
+
+export function DashboardEmptyState() {
+  return (
+    <div className="flex flex-1 items-center justify-center p-6">
+      <Card className="w-full max-w-2xl">
+        <CardContent className="flex flex-col items-center justify-center py-16 px-8">
+          <div className="text-center space-y-6">
+            <h2 className="text-2xl font-semibold text-gray-900">
+              No job post or contract in progress
+            </h2>
+            <Button className="bg-teal-600 hover:bg-teal-700 text-white px-6 py-3 rounded-full">
+              <Plus className="w-4 h-4 mr-2" />
+              Post Job
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/client-dashboard/Sidebar.tsx
+++ b/src/components/client-dashboard/Sidebar.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import {
+  LayoutDashboard,
+  Plus,
+  Search,
+  FolderOpen,
+  Wallet,
+  MessageSquare,
+  LogOut,
+} from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+const navigationItems = [
+  {
+    title: "Dashboard",
+    icon: LayoutDashboard,
+    href: "/dashboard",
+  },
+  {
+    title: "Create project",
+    icon: Plus,
+    href: "/dashboard/create-project",
+  },
+  {
+    title: "Search Talent",
+    icon: Search,
+    href: "/dashboard/search-talent",
+  },
+  {
+    title: "Manage project",
+    icon: FolderOpen,
+    href: "/dashboard/manage-project",
+  },
+  {
+    title: "Wallet",
+    icon: Wallet,
+    href: "/dashboard/wallet",
+  },
+  {
+    title: "Messages",
+    icon: MessageSquare,
+    href: "/dashboard/messages",
+  },
+];
+
+export function ClientSidebar() {
+  const pathname = usePathname();
+
+  return (
+    <div className="w-64 bg-white border-r border-gray-200 flex flex-col h-full">
+      <nav className="flex-1 p-2">
+        <ul className="space-y-1">
+          {navigationItems.map((item) => {
+            const isActive = pathname === item.href;
+            return (
+              <li key={item.href}>
+                <Link
+                  href={item.href}
+                  className={cn(
+                    "flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors",
+                    isActive
+                      ? "bg-teal-50 text-teal-700 border-r-2 border-teal-600"
+                      : "text-gray-700 hover:bg-gray-100 hover:text-gray-900"
+                  )}
+                >
+                  <item.icon className="w-4 h-4" />
+                  <span>{item.title}</span>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+
+      {/* Footer */}
+      <div className="p-2 border-t border-gray-200">
+        <button className="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium text-red-600 hover:bg-red-50 hover:text-red-700 w-full transition-colors">
+          <LogOut className="w-4 h-4" />
+          <span>Logout</span>
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# 📝 Implement Client Dashboard – Empty State

## 🛠️ Issue

- Closes #254

## 📚 Description

Implements the **Empty State view** for the Client Dashboard as defined in the Figma design: **Client Dashboard – Empty State**.

This state is shown when the user has no job posts or contracts currently in progress. It includes a centered message and a “Post Job” CTA button, designed to match the overall dashboard look and feel.

## ✅ Changes applied

- Created reusable component: `DashboardEmptyState.tsx`
- Displayed `DashboardEmptyState` inside `/dashboard/page.tsx` when there are no jobs or contracts
- Added a clean sub-header section with greeting + action button (`Post Job`)
- Implemented conditional rendering based on local `hasJobsOrContracts` state
- UI matches spacing, layout, and typography from Figma
- Fully responsive and aligned with overall dashboard layout

## 🔍 Evidence/Media (screenshots/videos)

<img width="1914" height="830" alt="Client Dashboard Empty State" src="https://github.com/user-attachments/assets/204fed60-ca9f-4a01-a2e3-a64f2a6f7d1f" />
