### PR TITLE
feat: Add TypeScript prop type definitions to React components

### DIFF
--- a/src/components/dispute-resolution/DisputeTabs.tsx
+++ b/src/components/dispute-resolution/DisputeTabs.tsx
@@ -10,7 +10,11 @@ const tabs = [
   { label: 'Resolved', value: 'resolved' },
 ];
 
-export default function DisputeTabs({ activeTab }: { activeTab: string }) {
+interface DisputeTabsProps {
+  activeTab: string;
+}
+
+export default function DisputeTabs({ activeTab }: DisputeTabsProps) {
   const pathname = usePathname();
 
   return (

--- a/src/components/messaging/MessageInput.tsx
+++ b/src/components/messaging/MessageInput.tsx
@@ -1,10 +1,12 @@
 'use client';
 import React, { useState } from 'react';
 
-export default function MessageInput({ onSend, onAttach }: {
+interface MessageInputProps {
   onSend: (text: string) => void;
   onAttach?: (file: File) => void;
-}) {
+}
+
+export default function MessageInput({ onSend, onAttach }: MessageInputProps) {
   const [value, setValue] = useState('');
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && value.trim()) {

--- a/src/components/messaging/MessageStatus.tsx
+++ b/src/components/messaging/MessageStatus.tsx
@@ -1,7 +1,11 @@
 "use client";
 export type MsgStatus = "sent" | "delivered" | "read";
 
-export default function MessageStatus({ status }: { status: MsgStatus }) {
+interface MessageStatusProps {
+  status: MsgStatus;
+}
+
+export default function MessageStatus({ status }: MessageStatusProps) {
   const label = status === "read" ? "✓✓" : status === "delivered" ? "✓✓" : "✓";
   const cls   = status === "read" ? "text-blue-500" : "text-gray-400";
   return <span className={`text-[10px] ${cls}`} aria-label={`status: ${status[0].toUpperCase()}${status.slice(1)}`}>{label}</span>;

--- a/src/components/onboarding/WalletContext.tsx
+++ b/src/components/onboarding/WalletContext.tsx
@@ -12,7 +12,11 @@ interface WalletContextType {
 
 const WalletContext = createContext<WalletContextType | undefined>(undefined);
 
-export function WalletProvider({ children }: { children: ReactNode }) {
+interface WalletProviderProps {
+  children: ReactNode;
+}
+
+export function WalletProvider({ children }: WalletProviderProps) {
 	const [address, setAddress] = useState<string | null>(null);
 	const [name, setName] = useState<string | null>(null);
 	const [connected, setConnected] = useState(false);

--- a/src/components/user-management/components/UserAnalyticsCardView.tsx
+++ b/src/components/user-management/components/UserAnalyticsCardView.tsx
@@ -2,11 +2,13 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { User } from "@/interfaces/user.interface"
 import { Copy, MoreHorizontal } from "lucide-react"
 
-export function UserAnalyticsCardView({ data, onViewAnalytics, onOverflowAction }: {
-    data: User[],
-    onViewAnalytics: (user: User) => void,
-    onOverflowAction: (action: string, userId: number) => void
-  }) {
+interface UserAnalyticsCardViewProps {
+  data: User[];
+  onViewAnalytics: (user: User) => void;
+  onOverflowAction: (action: string, userId: number) => void;
+}
+
+export function UserAnalyticsCardView({ data, onViewAnalytics, onOverflowAction }: UserAnalyticsCardViewProps) {
     return (
       <div className="md:hidden space-y-4">
         {data.map((user) => (

--- a/src/components/user-management/components/UserAnalyticsModal.tsx
+++ b/src/components/user-management/components/UserAnalyticsModal.tsx
@@ -3,11 +3,13 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { User } from "@/interfaces/user.interface"
 
-export function UserAnalyticsModal({ user, open, onClose }: {
-    user: User | null,
-    open: boolean,
-    onClose: () => void
-  }) {
+interface UserAnalyticsModalProps {
+  user: User | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function UserAnalyticsModal({ user, open, onClose }: UserAnalyticsModalProps) {
     const formatCurrency = (amount: number) => {
       return new Intl.NumberFormat("en-US", {
         style: "currency",


### PR DESCRIPTION
  # 📝 Pull Request Title
  Add TypeScript prop type definitions to React components

  ## 🛠️ Issue
  - Closes #549 

  ## 📚 Description
  Added proper TypeScript interface definitions for component props:
  - MessageInput: Added MessageInputProps interface
  - MessageStatus: Added MessageStatusProps interface
  - WalletProvider: Added WalletProviderProps interface
  - UserAnalyticsCardView: Added UserAnalyticsCardViewProps interface
  - DisputeTabs: Added DisputeTabsProps interface
  - UserAnalyticsModal: Added UserAnalyticsModalProps interface

  All props are now properly typed with descriptive interface names following naming
  conventions.

  ## ✅ Changes applied
  - Created TypeScript interfaces for 6 React components that were missing proper prop type
  definitions
  - Replaced inline type definitions with named interfaces
  - Used descriptive interface naming convention (ComponentName + Props)
  - Marked optional props with ? where applicable
  - Ensured all props are properly typed with appropriate TypeScript types

  ## 🔍 Evidence/Media (screenshots/videos)
  - 6 components now have proper TypeScript prop interfaces
  - No TypeScript errors introduced in the prop definitions
  - Follows project's existing TypeScript conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized component prop types using named interfaces across dispute resolution tabs, messaging input/status, wallet onboarding provider, and user analytics views/modals.
  - Improves type safety, readability, and maintainability without altering behavior or UI.
  - No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->