### PR TITLE
docs(auth): add JSDoc for POST /api/auth/login endpoint documenting r…

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -82,6 +82,30 @@ export async function register(
   }
 }
 
+/**
+ * Authenticate user login
+ * @route POST /api/auth/login
+ * @param req - Express request object
+ * @param res - Express response object
+ * @param next - Express next function
+ *
+ * Expected request body:
+ * {
+ *   "wallet_address": "string (required) - User's wallet address",
+ *   "signature": "string (required) - Signed message from wallet",
+ *   "nonce": "string (required) - Nonce used for signing"
+ * }
+ *
+ * Response format:
+ * {
+ *   "status": "success",
+ *   "user": { ... },
+ *   "tokens": {
+ *     "accessToken": "string",
+ *     "refreshToken": "string"
+ *   }
+ * }
+ */
 export async function login(req: Request, res: Response, next: NextFunction) {
   try {
     const { user, tokens } = await authService.login(req.body);


### PR DESCRIPTION

### 📝 Pull Request Title
docs(auth): add JSDoc for POST /api/auth/login endpoint

## 🛠️ Issue
- Closes #604 

## 📚 Description
Adds comprehensive JSDoc documentation for the `POST /api/auth/login` controller function to clarify required request body fields and the response structure. This improves developer experience and API discoverability.

## ✅ Changes applied
- Added JSDoc block above `login` in `backend/src/controllers/auth.controller.ts` documenting:
  - Expected request body fields with types and descriptions:
    - `wallet_address` (string, required)
    - `signature` (string, required)
    - `nonce` (string, required)
  - Response format including `status`, `user`, and `tokens` with `accessToken` and `refreshToken`.
- Verified linter on the modified file; only environment-level Express type resolution error detected (pre-existing/unrelated to this change).

## 🔍 Evidence/Media (screenshots/videos)
- File updated: `backend/src/controllers/auth.controller.ts`
- Branch: `docs/login-endpoint-jsdoc`

If you want, I can open the PR now and assign reviewers.