### PR TITLE
Standardize ProjectTabs to use UI tabs component

### DIFF
--- a/src/components/projects/ProjectTabs.tsx
+++ b/src/components/projects/ProjectTabs.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+
 interface Tab {
   key: string
   label: string
@@ -14,22 +16,19 @@ interface ProjectTabsProps {
 export function ProjectTabs({ tabs, activeTab, onTabChange }: ProjectTabsProps) {
   return (
     <div className="mx-auto w-full max-w-[680px]">
-      <div className="flex items-center justify-evenly gap-2 rounded-none bg-slate-700 px-4 py-2">
-        {tabs.map((t) => (
-          <button
-            key={t.key}
-            onClick={() => onTabChange(t.key)}
-            className={[
-              "rounded-none px-4 py-2 text-[15px] sm:text-base font-semibold transition",
-              activeTab === t.key ? "bg-teal-500 text-white shadow-sm" : "text-slate-100/90 hover:bg-slate-800",
-            ].join(" ")}
-            aria-pressed={activeTab === t.key}
-            aria-label={`Tab ${t.label}`}
-          >
-            {t.label}
-          </button>
-        ))}
-      </div>
+      <Tabs value={activeTab} onValueChange={onTabChange}>
+        <TabsList className="flex items-center justify-evenly gap-2 rounded-none bg-slate-700 px-4 py-2 h-auto">
+          {tabs.map((t) => (
+            <TabsTrigger
+              key={t.key}
+              value={t.key}
+              className="rounded-none px-4 py-2 text-[15px] sm:text-base font-semibold transition data-[state=active]:bg-teal-500 data-[state=active]:text-white data-[state=active]:shadow-sm data-[state=inactive]:text-slate-100/90 data-[state=inactive]:hover:bg-slate-800"
+            >
+              {t.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
     </div>
   )
 }


### PR DESCRIPTION
# 📝 Pull Request Title

**feat: standardize ProjectTabs to use UI tabs component**

## ��️ Issue

- Closes #685

## 📚 Description

- Updated `ProjectTabs.tsx` to use the standardized UI tabs component instead of custom button implementation
- Maintained existing visual styling and behavior while improving accessibility
- Ensured consistent tab behavior across the application

## ✅ Changes applied

- **File modified:** `src/components/projects/ProjectTabs.tsx`
  - Replaced custom button elements with `TabsTrigger` from `@/components/ui/tabs`
  - Added proper imports for `Tabs`, `TabsList`, and `TabsTrigger`
  - Maintained existing className styling for slate-700 background and teal-500 active state
  - Preserved all existing props and functionality (`tabs`, `activeTab`, `onTabChange`)

## 🔍 Evidence/Media (screenshots/videos)

- **Before:** Custom button implementation with manual state management
- **After:** Radix UI tabs with built-in accessibility features
- **Benefits:** 
  - ✅ Consistent behavior with other tab components in the project
  - ✅ Improved keyboard navigation and focus management
  - ✅ Automatic ARIA attributes for better accessibility
  - ✅ Easier maintenance with standardized component usage

**Code changes:**
```tsx
// Before: Custom buttons
<button onClick={() => onTabChange(t.key)} className={...}>

// After: Standardized tabs
<TabsTrigger value={t.key} className={...}>
```