### PR TITLE
 Added a manual refresh button to the Analytics Dashboard to allow users to manually update data

### DIFF
--- a/src/components/applications/analytics-dashboard.tsx
+++ b/src/components/applications/analytics-dashboard.tsx
@@ -11,6 +11,7 @@ import {
 import {
   Button,
 } from '@/components/ui/button';
+import { RefreshCw } from 'lucide-react';
 import {
   Select,
   SelectContent,
@@ -418,6 +419,7 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
     applyFilters,
     clearFilters,
     currentFilters,
+    refreshAllData,
   } = useApplicationAnalytics({
     autoRefresh: true,
     refreshInterval: 60000, // 1 minute
@@ -505,6 +507,19 @@ export const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({
           </p>
         </div>
         <div className="flex items-center space-x-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={refreshAllData}
+            disabled={loading.isLoading}
+          >
+            {loading.isLoading ? (
+              <RefreshCw className="h-4 w-4 animate-spin mr-2" />
+            ) : (
+              <RefreshCw className="h-4 w-4 mr-2" />
+            )}
+            Refresh
+          </Button>
           <Badge variant="secondary">
             {applications.length} Applications
           </Badge>


### PR DESCRIPTION
# 📝 Pull Request Title

## 🛠️ Issue

- Closes #683

## 📚 Description

Added a manual refresh button to the Analytics Dashboard to allow users to manually update data, improving user experience by providing direct control over data refresh functionality.

## ✅ Changes applied

- **Added manual refresh button** in the Analytics Dashboard header
- **Imported RefreshCw icon** from lucide-react for visual consistency
- **Implemented refreshAllData functionality** from useApplicationAnalytics hook
- **Added loading state** with icon animation during refresh
- **Button disables** during loading process to prevent multiple requests

## �� Evidence/Media (screenshots/videos)

- Button appears in the top-right corner of the dashboard next to information badges
- Shows rotation animation during loading
- Automatically disables while data is being updated
- Follows the same visual pattern as other project dashboards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Refresh button to the Analytics Dashboard header to manually reload all analytics data.

* **Improvements**
  * Displays a loading spinner on the Refresh button during updates.
  * Disables the Refresh button while data is loading to prevent duplicate actions.
  * Provides clearer feedback on refresh status for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->