### PR TITLE
feat: Create Reusable Badge Components for Status Indicators and Labels

### DIFF
--- a/src/components/profile/skill-tag.tsx
+++ b/src/components/profile/skill-tag.tsx
@@ -11,7 +11,7 @@ import {
   TrendingUp,
 } from "lucide-react";
 
-
+import { Badge } from "@/components/ui/badge";
 import { skillCategories } from "../../data/skills-categories";
 import type { Skill } from "../../data/skills-categories";
 
@@ -27,10 +27,10 @@ export const SkillTag: React.FC<{
   const [showLevelSelector, setShowLevelSelector] = useState(false);
 
   const category = skillCategories.find((cat) => cat.id === skill.category);
-  const levelColors = {
-    Beginner: "bg-yellow-100 text-yellow-800 border-yellow-300",
-    Intermediate: "bg-blue-100 text-blue-800 border-blue-300",
-    Advanced: "bg-green-100 text-green-800 border-green-300",
+  const levelVariants = {
+    Beginner: "warning" as const,
+    Intermediate: "default" as const,
+    Advanced: "success" as const,
   };
 
   const levelIcons = {
@@ -65,13 +65,13 @@ export const SkillTag: React.FC<{
       <div className="relative">
         <button
           onClick={() => setShowLevelSelector(!showLevelSelector)}
-          className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium border transition-colors ${
-            levelColors[skill.level]
-          }`}
+          className="flex items-center gap-1"
         >
-          <LevelIcon className="w-3 h-3" />
-          <span>{skill.level}</span>
-          <ChevronDown className="w-3 h-3" />
+          <Badge variant={levelVariants[skill.level]} className="flex items-center gap-1">
+            <LevelIcon className="w-3 h-3" />
+            <span>{skill.level}</span>
+            <ChevronDown className="w-3 h-3" />
+          </Badge>
         </button>
 
         {showLevelSelector && (
@@ -112,18 +112,19 @@ export const SkillTag: React.FC<{
       </button>
 
       {skill.demand && (
-        <div
-          className={`px-2 py-1 rounded-full text-xs font-medium ${
-            skill.demand === "High"
-              ? "bg-red-100 text-red-700"
-              : skill.demand === "Medium"
-              ? "bg-orange-100 text-orange-700"
-              : "bg-gray-100 text-gray-700"
-          }`}
+        <Badge 
+          variant={
+            skill.demand === "High" 
+              ? "destructive" 
+              : skill.demand === "Medium" 
+              ? "warning" 
+              : "secondary"
+          }
+          className="flex items-center gap-1"
         >
-          <TrendingUp className="w-3 h-3 inline mr-1" />
+          <TrendingUp className="w-3 h-3" />
           {skill.demand}
-        </div>
+        </Badge>
       )}
     </div>
   );

--- a/src/components/projects/ProjectStatusBadge.tsx
+++ b/src/components/projects/ProjectStatusBadge.tsx
@@ -12,22 +12,22 @@ export function ProjectStatusBadge({ status }: ProjectStatusBadgeProps) {
       case "active":
         return {
           label: "Active",
-          className: "bg-blue-100 text-blue-700 hover:bg-blue-100"
+          variant: "default" as const
         }
       case "completed":
         return {
           label: "Completed",
-          className: "bg-green-100 text-green-700 hover:bg-green-100"
+          variant: "success" as const
         }
       case "dispute":
         return {
           label: "Dispute",
-          className: "bg-red-100 text-red-700 hover:bg-red-100"
+          variant: "destructive" as const
         }
       default:
         return {
           label: "Unknown",
-          className: "bg-gray-100 text-gray-700 hover:bg-gray-100"
+          variant: "secondary" as const
         }
     }
   }
@@ -35,7 +35,7 @@ export function ProjectStatusBadge({ status }: ProjectStatusBadgeProps) {
   const config = getStatusConfig(status)
 
   return (
-    <Badge variant="secondary" className={config.className}>
+    <Badge variant={config.variant}>
       {config.label}
     </Badge>
   )


### PR DESCRIPTION
# 📝 Pull Request Title

**feat: Create Reusable Badge Components for Status Indicators and Labels**

## 🛠️ Issue

- Closes #667

## 📚 Description

This PR implements standardized badge components for status indicators and labels across the platform. The changes ensure consistent styling and behavior for all badge elements by leveraging the existing Badge component from the UI library.

## ✅ Changes applied

- **ProjectStatusBadge**: Updated to use standardized badge variants instead of custom CSS classes
  - `active` status now uses `default` variant
  - `completed` status now uses `success` variant  
  - `dispute` status now uses `destructive` variant
- **SkillTag**: Refactored to use Badge component for skill levels and demand indicators
  - Skill levels (Beginner/Intermediate/Advanced) now use consistent badge styling
  - Demand indicators (High/Medium/Low) now use appropriate badge variants
- **Consistent styling**: All badge elements now follow the same design system with proper variants

## 🔍 Evidence/Media (screenshots/videos)

- Badge components now use consistent variants from the UI library
- Project status badges maintain visual hierarchy with appropriate colors
- Skill tags display levels and demand with standardized badge styling
- All changes maintain existing functionality while improving consistency