### PR TITLE
feat: add copy to clipboard functionality

### DIFF
--- a/src/components/common/copy-button.tsx
+++ b/src/components/common/copy-button.tsx
@@ -1,0 +1,39 @@
+import { Copy, Check } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useClipboard } from '@/hooks/use-clipboard';
+
+interface CopyButtonProps {
+  text: string;
+  className?: string;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+export function CopyButton({ text, className, size = 'sm' }: CopyButtonProps) {
+  const { copied, copy } = useClipboard();
+
+  const handleCopy = () => {
+    copy(text);
+  };
+
+  const sizeClasses = {
+    sm: 'h-8 px-2',
+    md: 'h-10 px-3',
+    lg: 'h-12 px-4'
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={handleCopy}
+      className={`${sizeClasses[size]} ${className}`}
+    >
+      {copied ? (
+        <Check className="h-4 w-4 mr-2 text-green-600" />
+      ) : (
+        <Copy className="h-4 w-4 mr-2" />
+      )}
+      {copied ? 'Copied!' : 'Copy'}
+    </Button>
+  );
+}

--- a/src/components/projects/project-share.tsx
+++ b/src/components/projects/project-share.tsx
@@ -1,0 +1,24 @@
+import { Share2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { CopyButton } from '@/components/common/copy-button';
+
+interface ProjectShareProps {
+  projectId: string;
+  projectTitle: string;
+  className?: string;
+}
+
+export function ProjectShare({ projectId, projectTitle, className }: ProjectShareProps) {
+  const projectUrl = `${window.location.origin}/projects/${projectId}`;
+  const shareText = `Check out this project: ${projectTitle} - ${projectUrl}`;
+
+  return (
+    <div className={`flex items-center gap-2 ${className}`}>
+      <Button variant="outline" size="sm">
+        <Share2 className="h-4 w-4 mr-2" />
+        Share Project
+      </Button>
+      <CopyButton text={shareText} />
+    </div>
+  );
+}

--- a/src/hooks/use-clipboard.ts
+++ b/src/hooks/use-clipboard.ts
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+
+interface UseClipboardReturn {
+  copied: boolean;
+  copy: (text: string) => Promise<boolean>;
+}
+
+export function useClipboard(): UseClipboardReturn {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async (text: string): Promise<boolean> => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+      return true;
+    } catch (error) {
+      console.error('Failed to copy to clipboard:', error);
+      return false;
+    }
+  };
+
+  return { copied, copy };
+}


### PR DESCRIPTION

# 📝 Pull Request Title
**feat: add copy to clipboard functionality**

## 🛠️ Issue
- Closes #666

## 📚 Description
- Implemented copy to clipboard functionality for project sharing
- Created reusable hook `useClipboard` for clipboard operations
- Added `CopyButton` component with visual feedback
- Created `ProjectShare` component that integrates copy functionality
- All components follow project organization rules (kebab-case, single responsibility)

## ✅ Changes applied
- **Added** `src/hooks/use-clipboard.ts` - Custom hook for clipboard operations
- **Added** `src/components/common/copy-button.tsx` - Reusable copy button component
- **Added** `src/components/projects/project-share.tsx` - Project sharing component with copy functionality
- **Features**: Visual feedback on copy success, error handling, TypeScript support

## 🔍 Evidence/Media (screenshots/videos)
- Implementation is functional and simple (max 50 lines per file)
- No linting errors
- Follows project structure and naming conventions
- Ready for testing and integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a reusable copy button that copies text to the clipboard with clear success feedback.
  * Added a project sharing control that generates a shareable message with title and link, with one-click copy.
  * Implemented app-wide clipboard handling to provide consistent copy behavior and temporary “copied” state across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->