### PR TITLE
feat: add use-toast hook for simple toast notifications

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useNotification } from '@/lib/contexts/NotificatonContext';
+
+export interface ToastOptions {
+  title?: string;
+  message: string;
+  actionUrl?: string;
+  actionLabel?: string;
+}
+
+export interface UseToastReturn {
+  toast: {
+    success: (message: string, options?: Omit<ToastOptions, 'message'>) => void;
+    error: (message: string, options?: Omit<ToastOptions, 'message'>) => void;
+    warning: (message: string, options?: Omit<ToastOptions, 'message'>) => void;
+    info: (message: string, options?: Omit<ToastOptions, 'message'>) => void;
+  };
+}
+
+/**
+ * Simple toast hook that provides easy-to-use toast notifications
+ * Uses the existing NotificationContext for consistency
+ */
+export function useToast(): UseToastReturn {
+  const { actions } = useNotification();
+
+  const showToast = (
+    type: 'success' | 'error' | 'warning' | 'info',
+    message: string,
+    options: Omit<ToastOptions, 'message'> = {}
+  ) => {
+    actions.showToast({
+      type,
+      title: options.title || type.charAt(0).toUpperCase() + type.slice(1),
+      message,
+      actionUrl: options.actionUrl,
+      actionLabel: options.actionLabel,
+    });
+  };
+
+  return {
+    toast: {
+      success: (message, options) => showToast('success', message, options),
+      error: (message, options) => showToast('error', message, options),
+      warning: (message, options) => showToast('warning', message, options),
+      info: (message, options) => showToast('info', message, options),
+    },
+  };
+}


### PR DESCRIPTION


# 📝 Pull Request Title

## 🛠️ Issue

- Closes #776

## 📚 Description

- Implemented a simple and functional `use-toast` hook to provide easy-to-use toast notifications
- The hook integrates seamlessly with the existing NotificationContext system
- Provides a clean API with methods for different toast types (success, error, warning, info)
- Maintains consistency with the project's architecture and naming conventions

## ✅ Changes applied

- Added `src/hooks/use-toast.ts` with 50 lines of functional code
- Hook provides `toast.success()`, `toast.error()`, `toast.warning()`, and `toast.info()` methods
- Full TypeScript support with proper interfaces and type definitions
- Uses existing NotificationContext for consistency with current notification system
- Follows project's kebab-case naming convention for hooks

## 🔍 Evidence/Media (screenshots/videos)

- No visual changes as this is a utility hook implementation
- Hook is ready to be used throughout the application for consistent toast notifications
