### PR TITLE
feat(accessibility): Add visble focus indicators for focusable elements (input.tsx, button.tsx)

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,9 +5,10 @@ import { Loader2 } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import "@/styles/animations.css"
+import "@/styles/focus.css"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 ease-in-out focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 btn-smooth hover:scale-105 hover:shadow-md",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 ease-in-out focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 btn-smooth hover:scale-105 hover:shadow-md focus-ring",
   {
     variants: {
       variant: {
@@ -38,7 +39,7 @@ const buttonVariants = cva(
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
+  VariantProps<typeof buttonVariants> {
   asChild?: boolean
   isLoading?: boolean
 }
@@ -61,6 +62,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
+        data-variant={variant}
         disabled={isLoading || props.disabled}
         {...props}
       >

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
+import "@/styles/focus.css";
 
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
   ({ className, type, ...props }, ref) => {
@@ -8,7 +9,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-[16px] border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          "flex h-10 w-full rounded-[16px] border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-ring",
           className
         )}
         ref={ref}

--- a/src/styles/focus.css
+++ b/src/styles/focus.css
@@ -1,0 +1,83 @@
+/* Accessible focus styles for keyboard navigation
+   - Uses :focus-visible so mouse focus isn't noisy
+   - Provides a utility class `.focus-ring` for explicit application
+   - Uses CSS variables with sensible fallbacks; uses !important to ensure visibility
+*/
+:root {
+  --oh-focus-width: 3px;
+  --oh-focus-offset: 3px;
+  --oh-focus-shadow-alpha: 0.12;
+  /* Primary focus color (teal) - will be used in place of global.css --ring */
+  --oh-focus-color: #15949C;
+  --oh-focus-color-rgb: 21 148 156;
+  /* used with theme color */
+}
+
+/* Remove default outline but keep focus-visible for keyboard users */
+:focus {
+  outline: none;
+}
+
+/* Fallback focus style uses the global --ring token */
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+a:focus-visible,
+[role="button"]:focus-visible {
+  outline: var(--oh-focus-width) solid var(--oh-focus-color, hsl(var(--ring))) !important;
+  /*
+    outline: var(--oh-focus-width) solid var(--oh-focus-color, hsl(var(--ring))) !important; 
+  */
+  outline-offset: var(--oh-focus-offset) !important;
+  box-shadow: 0 0 0 6px rgb(var(--oh-focus-color-rgb) / var(--oh-focus-shadow-alpha, 0.12)) !important;
+}
+
+/* Variant-aware button focus rules: prefer button color tokens when available */
+button[data-variant="default"]:focus-visible,
+.btn-smooth[data-variant="default"]:focus-visible {
+  /* Use the explicit primary focus color to match button primary */
+  outline: var(--oh-focus-width) solid var(--oh-focus-color, hsl(var(--primary))) !important;
+  outline-offset: var(--oh-focus-offset) !important;
+  box-shadow: 0 0 0 6px rgb(var(--oh-focus-color-rgb) / var(--oh-focus-shadow-alpha, 0.12)) !important;
+}
+
+button[data-variant="destructive"]:focus-visible,
+.btn-smooth[data-variant="destructive"]:focus-visible {
+  outline: var(--oh-focus-width) solid hsl(var(--destructive)) !important;
+  outline-offset: var(--oh-focus-offset) !important;
+  box-shadow: 0 0 0 6px hsl(var(--destructive) / var(--oh-focus-shadow-alpha, 0.12)) !important;
+}
+
+button[data-variant="secondary"]:focus-visible,
+.btn-smooth[data-variant="secondary"]:focus-visible {
+  outline: var(--oh-focus-width) solid hsl(var(--secondary)) !important;
+  outline-offset: var(--oh-focus-offset) !important;
+  box-shadow: 0 0 0 6px hsl(var(--secondary) / var(--oh-focus-shadow-alpha, 0.12)) !important;
+}
+
+/* Outline/ghost/link variants use the ring token to avoid clashing */
+button[data-variant="outline"]:focus-visible,
+button[data-variant="ghost"]:focus-visible,
+button[data-variant="link"]:focus-visible,
+.btn-smooth[data-variant="outline"]:focus-visible,
+.btn-smooth[data-variant="ghost"]:focus-visible,
+.btn-smooth[data-variant="link"]:focus-visible {
+  outline: var(--oh-focus-width) solid var(--oh-focus-color, hsl(var(--ring))) !important;
+  outline-offset: var(--oh-focus-offset) !important;
+  box-shadow: 0 0 0 6px rgb(var(--oh-focus-color-rgb) / var(--oh-focus-shadow-alpha, 0.12)) !important;
+}
+
+/* Utility class to opt-in on elements that need the ring explicitly */
+.focus-ring:focus-visible {
+  outline: var(--oh-focus-width) solid var(--oh-focus-color, hsl(var(--ring))) !important;
+  outline-offset: var(--oh-focus-offset) !important;
+  box-shadow: 0 0 0 6px rgb(var(--oh-focus-color-rgb) / var(--oh-focus-shadow-alpha, 0.12)) !important;
+}
+
+/* Slightly smaller ring for compact controls */
+.focus-ring--sm:focus-visible {
+  outline: 2px solid var(--oh-focus-color, hsl(var(--ring))) !important;
+  outline-offset: 2px !important;
+  box-shadow: 0 0 0 4px rgb(var(--oh-focus-color-rgb) / var(--oh-focus-shadow-alpha, 0.12)) !important;
+}

--- a/src/styles/focus.css
+++ b/src/styles/focus.css
@@ -13,8 +13,8 @@
   /* used with theme color */
 }
 
-/* Remove default outline but keep focus-visible for keyboard users */
-:focus {
+/* Keep default focus but changes outline to non on focus-visible */
+:focus:not(:focus-visible) {
   outline: none;
 }
 


### PR DESCRIPTION
## 🛠️ Issue 

- Closes #660 

## 📚 Description
- This PR Implements accessible, theme-aware focus indicators for keyboard users.
- Adds focused outline + subtle shadow that follows the project theme and uses the requested primary color (`#15949C`) as the default 
   `I didnt use the --ring (`--ring: 0 0% 3.9%;`) feature because of the off blend with the background `
- Focus indicators are applied to **buttons** and **inputs** and are variant-aware for primary/destructive/secondary buttons 

## ✅ Changes applied
- **Added** `focus.css` - `:focus-visible` rules, `.focus-ring` and `.focus-ring--sm` utilities; default focus color set to `15949C` with fallbacks to theme tokens.
- **Updated** `button.tsx` — import `focus.css`, added `focus-ring` utility and `data-variant={variant}` to allow variant-specific focus styles.
- **Updated** `input.tsx` — import `focus.css` and added `focus-ring` utility.

## Files modified
- Added: `focus.css`
- Modified: `button.tsx`
- Modified: `input.tsx`

Task
- [x] Create focus styles — **Done** (`focus.css`)
- [x] Add focus indicators to buttons — **Done** (`button.tsx` includes `focus-ring` + `data-variant`)
- [x] Add focus indicators to inputs — **Done** (`input.tsx` includes `focus-ring`)
- [x] Test keyboard navigation — **Manual steps provided**

## 🔍 Evidence/Media (screenshots/videos)

https://github.com/user-attachments/assets/77dde42d-ecb5-45c3-a77b-65fec1b0b644


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Introduced a new focus styling system for accessible, high-contrast focus rings across interactive elements.
  * Added a reusable focus-ring utility (with a compact variant) and unified focus rules via a shared stylesheet.
  * Updated button and input components to adopt the new focus styles, improving keyboard navigation visibility and hover/focus interactions.
  * Applied variant-specific focus colors and refined focus semantics.

* **New Features**
  * Button elements now expose a data-variant attribute in the DOM for styling/accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->