### PR TITLE
fix(escrow): implement platform wallet for refund flow via dispute+resolve

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,8 @@ TRUSTLESS_API_KEY=your_api_key_here
 TRUSTLESS_API_URL=https://dev.api.trustlesswork.com
 TRUSTLESS_WEBHOOK_SECRET=tw_whsec_...
 TRUSTLESS_TIMEOUT_MS=60000
+# Platform user (must have a Stellar wallet) — used as disputeResolver & platformAddress in escrows
+PLATFORM_USER_ID=usr_your_platform_user_id
 
 # --------------------------------------------
 # Stellar

--- a/apps/api/src/modules/orders/__tests__/orders.service.spec.ts
+++ b/apps/api/src/modules/orders/__tests__/orders.service.spec.ts
@@ -5,6 +5,7 @@ import { OrdersService } from '../orders.service';
 import { PrismaService } from '../../database/prisma.service';
 import { BalanceService } from '../../balance/balance.service';
 import { EscrowClient } from '../../../providers/trustless-work/clients/escrow.client';
+import { TrustlessWorkConfig } from '../../../providers/trustless-work/trustless-work.config';
 import { PAYMENT_PROVIDER } from '../../../providers/payment/payment-provider.interface';
 import type { CreateOrderDto, MilestoneDto } from '../dto';
 import {
@@ -160,6 +161,12 @@ describe('OrdersService', () => {
                     useValue: {
                         createEscrow: jest.fn(),
                         fundEscrow: jest.fn(),
+                    },
+                },
+                {
+                    provide: TrustlessWorkConfig,
+                    useValue: {
+                        platformUserId: 'platform-user-1',
                     },
                 },
                 {

--- a/apps/api/src/modules/orders/orders.service.ts
+++ b/apps/api/src/modules/orders/orders.service.ts
@@ -27,6 +27,7 @@ import {
 import { PrismaService } from '../database/prisma.service';
 import { BalanceService } from '../balance/balance.service';
 import { EscrowClient } from '../../providers/trustless-work/clients/escrow.client';
+import { TrustlessWorkConfig } from '../../providers/trustless-work/trustless-work.config';
 import { InsufficientFundsException } from '../balance/exceptions';
 import {
     OrderNotFoundException,
@@ -68,6 +69,7 @@ export class OrdersService {
         @Inject(PrismaService) private readonly prisma: PrismaService,
         @Inject(BalanceService) private readonly balanceService: BalanceService,
         @Inject(EscrowClient) private readonly escrowClient: EscrowClient,
+        @Inject(TrustlessWorkConfig) private readonly twConfig: TrustlessWorkConfig,
         @Inject(PAYMENT_PROVIDER) private readonly paymentProvider: PaymentProvider,
         @Inject(EventBusService) private readonly eventBus: EventBusService,
     ) { }
@@ -374,14 +376,16 @@ export class OrdersService {
             throw new Error('Both buyer and seller must have active payment accounts');
         }
 
-        // Get payment addresses for escrow
-        const [buyerDeposit, sellerDeposit] = await Promise.all([
+        // Get payment addresses for escrow (buyer, seller, platform)
+        const [buyerDeposit, sellerDeposit, platformDeposit] = await Promise.all([
             this.paymentProvider.getDepositInfo(order.buyerId),
             this.paymentProvider.getDepositInfo(order.sellerId),
+            this.paymentProvider.getDepositInfo(this.twConfig.platformUserId),
         ]);
 
         const buyerAddress = buyerDeposit.address!;
         const sellerAddress = sellerDeposit.address!;
+        const platformAddress = platformDeposit.address!;
 
         try {
             await this.prisma.$transaction(
@@ -431,6 +435,7 @@ export class OrdersService {
                     },
                 },
                 buyerAddress,
+                platformAddress,
             );
 
             // Sign the unsigned XDR with buyer's invisible wallet and submit to Stellar

--- a/apps/api/src/modules/resolution/resolution.service.ts
+++ b/apps/api/src/modules/resolution/resolution.service.ts
@@ -16,6 +16,7 @@ import { Prisma, MilestoneStatus } from '@prisma/client';
 import { PrismaService } from '../database/prisma.service';
 import { BalanceService } from '../balance/balance.service';
 import { EscrowClient } from '../../providers/trustless-work/clients/escrow.client';
+import { TrustlessWorkConfig } from '../../providers/trustless-work/trustless-work.config';
 import { PAYMENT_PROVIDER, PaymentProvider } from '../../providers/payment/payment-provider.interface';
 import { OrdersService, OrderWithRelations } from '../orders/orders.service';
 import {
@@ -94,6 +95,7 @@ export class ResolutionService {
         @Inject(PrismaService) private readonly prisma: PrismaService,
         @Inject(BalanceService) private readonly balanceService: BalanceService,
         @Inject(EscrowClient) private readonly escrowClient: EscrowClient,
+        @Inject(TrustlessWorkConfig) private readonly twConfig: TrustlessWorkConfig,
         @Inject(PAYMENT_PROVIDER) private readonly paymentProvider: PaymentProvider,
         @Inject(OrdersService) private readonly ordersService: OrdersService,
         @Inject(EventBusService) private readonly eventBus: EventBusService,
@@ -501,24 +503,52 @@ export class ResolutionService {
             },
         );
 
-        // 7. Call escrowClient.refundEscrow + sign+send
+        // 7. Refund via TW: dispute-escrow + resolve-dispute (TW has no /refund endpoint)
         const escrowType =
             order.milestones && order.milestones.length > 1 ? 'multi-release' : 'single-release';
 
+        const [buyerDeposit, platformDeposit] = await Promise.all([
+            this.paymentProvider.getDepositInfo(order.buyerId),
+            this.paymentProvider.getDepositInfo(this.twConfig.platformUserId),
+        ]);
+        const buyerAddress = buyerDeposit.address!;
+        const platformAddress = platformDeposit.address!;
+
         try {
-            const refundResult = await this.escrowClient.refundEscrow(
+            // Step 1: Dispute the escrow (buyer signs — any party except disputeResolver can dispute)
+            this.logger.debug(`Refund step 1/2: Disputing escrow for order ${orderId}`);
+            const disputeResult = await this.escrowClient.disputeEscrow(
                 order.escrow.trustlessContractId!,
+                buyerAddress,
                 escrowType,
             );
 
-            // Sign and submit refund transaction if unsigned XDR returned
-            if (refundResult.unsignedTransaction) {
+            if (disputeResult.unsignedTransaction) {
                 const signedXdr = await this.paymentProvider.signEscrowTransaction(
                     order.buyerId,
-                    refundResult.unsignedTransaction,
+                    disputeResult.unsignedTransaction,
                 );
                 await this.escrowClient.sendTransaction(signedXdr);
-                this.logger.log(`Refund transaction signed and submitted for order ${orderId}`);
+                this.logger.log(`Refund step 1/2: Escrow disputed for order ${orderId}`);
+            }
+
+            // Step 2: Resolve dispute with 100% to buyer (platform signs as disputeResolver)
+            this.logger.debug(`Refund step 2/2: Resolving dispute for refund on order ${orderId}`);
+            const resolveResult = await this.escrowClient.resolveDisputeForRefund(
+                order.escrow.trustlessContractId!,
+                platformAddress,
+                buyerAddress,
+                order.amount,
+                escrowType,
+            );
+
+            if (resolveResult.unsignedTransaction) {
+                const signedXdr = await this.paymentProvider.signEscrowTransaction(
+                    this.twConfig.platformUserId,
+                    resolveResult.unsignedTransaction,
+                );
+                await this.escrowClient.sendTransaction(signedXdr);
+                this.logger.log(`Refund step 2/2: Dispute resolved, funds returned to buyer for order ${orderId}`);
             }
         } catch (error: any) {
             this.logger.error(`Failed to refund escrow for order ${orderId}:`, error);
@@ -1134,19 +1164,45 @@ export class ResolutionService {
     ): Promise<void> {
         this.logger.debug(`Executing full refund for dispute ${dispute.id}`);
 
-        // Calls escrowClient.refundEscrow() + sign+send
+        // TW has no /refund endpoint — use dispute-escrow + resolve-dispute (2-step)
         const escrowType =
             order.milestones && order.milestones.length > 1 ? 'multi-release' : 'single-release';
 
-        const refundResult = await this.escrowClient.refundEscrow(
+        const [buyerDeposit, platformDeposit] = await Promise.all([
+            this.paymentProvider.getDepositInfo(order.buyerId),
+            this.paymentProvider.getDepositInfo(this.twConfig.platformUserId),
+        ]);
+        const buyerAddress = buyerDeposit.address!;
+        const platformAddress = platformDeposit.address!;
+
+        // Step 1: Dispute the escrow (buyer signs)
+        const disputeResult = await this.escrowClient.disputeEscrow(
             order.escrow!.trustlessContractId!,
+            buyerAddress,
             escrowType,
         );
 
-        if (refundResult.unsignedTransaction) {
+        if (disputeResult.unsignedTransaction) {
             const signedXdr = await this.paymentProvider.signEscrowTransaction(
                 order.buyerId,
-                refundResult.unsignedTransaction,
+                disputeResult.unsignedTransaction,
+            );
+            await this.escrowClient.sendTransaction(signedXdr);
+        }
+
+        // Step 2: Resolve dispute with 100% to buyer (platform signs as disputeResolver)
+        const resolveResult = await this.escrowClient.resolveDisputeForRefund(
+            order.escrow!.trustlessContractId!,
+            platformAddress,
+            buyerAddress,
+            order.amount,
+            escrowType,
+        );
+
+        if (resolveResult.unsignedTransaction) {
+            const signedXdr = await this.paymentProvider.signEscrowTransaction(
+                this.twConfig.platformUserId,
+                resolveResult.unsignedTransaction,
             );
             await this.escrowClient.sendTransaction(signedXdr);
         }

--- a/apps/api/src/providers/trustless-work/clients/escrow.client.ts
+++ b/apps/api/src/providers/trustless-work/clients/escrow.client.ts
@@ -6,8 +6,6 @@ import {
     TrustlessEscrowContract,
     TrustlessFundingResult,
     TrustlessReleaseResult,
-    TrustlessRefundResult,
-    mapTrustlessStatus,
 } from '../types/trustless-work.types';
 import { CreateEscrowDto } from '../dto/escrow.dto';
 import { DisputeResolutionDto } from '../dto/dispute-resolution.dto';
@@ -47,6 +45,7 @@ export class EscrowClient {
     async createEscrow(
         data: CreateEscrowDto,
         signerAddress: string,
+        platformAddress: string,
     ): Promise<TrustlessInitializeEscrowResponse> {
         try {
             this.logger.debug(`Creating escrow for order: ${data.order_id}`);
@@ -89,9 +88,9 @@ export class EscrowClient {
                 roles: {
                     approver: data.buyer_address, // Buyer approves work
                     serviceProvider: data.seller_address, // Seller provides service
-                    platformAddress: signerAddress, // Platform receives fees (must have USDC trustline!)
+                    platformAddress: platformAddress, // Platform receives fees (must have USDC trustline!)
                     releaseSigner: data.buyer_address, // Buyer releases funds
-                    disputeResolver: data.buyer_address, // Buyer resolves disputes
+                    disputeResolver: platformAddress, // Platform resolves disputes (MUST differ from disputer)
                     receiver: data.seller_address, // Seller receives funds
                 },
                 amount: amount,
@@ -337,32 +336,74 @@ export class EscrowClient {
     }
 
     /**
-     * Refund escrow funds.
-     * TW API pattern: POST /escrow/single-release/refund with { contractId }
+     * Dispute an escrow (step 1 of refund flow).
+     * TW API: POST /escrow/{type}/dispute-escrow
+     * Returns unsigned XDR that must be signed by the signer.
      */
-    async refundEscrow(
+    async disputeEscrow(
         contractId: string,
+        signerAddress: string,
         escrowType: 'single-release' | 'multi-release' = 'single-release',
-    ): Promise<TrustlessRefundResult> {
+    ): Promise<{ unsignedTransaction?: string; transaction_hash?: string }> {
         try {
-            this.logger.debug(`Refunding escrow: ${contractId}`);
+            this.logger.debug(`Disputing escrow: ${contractId} (signer: ${signerAddress})`);
 
             const payload = {
                 contractId,
+                signer: signerAddress,
             };
 
-            const response = await this.post<TrustlessRefundResult>(
-                `/escrow/${escrowType}/refund`,
+            const response = await this.post<{ unsignedTransaction?: string; transaction_hash?: string }>(
+                `/escrow/${escrowType}/dispute-escrow`,
                 payload,
             );
 
-            this.logger.log(
-                `Escrow ${contractId} refund initiated. Tx: ${response.transaction_hash}`,
-            );
-
+            this.logger.log(`Escrow ${contractId} dispute initiated`);
             return response;
         } catch (error: any) {
-            this.logger.error(`Failed to refund escrow ${contractId}:`, error);
+            this.logger.error(`Failed to dispute escrow ${contractId}:`, error);
+            throw this.handleApiError(error);
+        }
+    }
+
+    /**
+     * Step 2 of refund: Resolve dispute with 100% to buyer.
+     * Called after the dispute transaction has been signed and submitted.
+     * TW API: POST /escrow/{type}/resolve-dispute
+     */
+    async resolveDisputeForRefund(
+        contractId: string,
+        disputeResolverAddress: string,
+        buyerAddress: string,
+        amount: string,
+        escrowType: 'single-release' | 'multi-release' = 'single-release',
+    ): Promise<{ unsignedTransaction?: string; transaction_hash?: string }> {
+        try {
+            this.logger.debug(`Step 2/2: Resolving dispute for refund on escrow ${contractId}`);
+
+            // TW expects USDC amounts (not stroops) — consistent with deploy and fund
+            const amountUsdc = parseFloat(amount);
+
+            const payload = {
+                contractId,
+                disputeResolver: disputeResolverAddress,
+                distributions: [
+                    {
+                        address: buyerAddress,
+                        amount: amountUsdc,
+                    },
+                ],
+            };
+
+            const response = await this.post<{ unsignedTransaction?: string; transaction_hash?: string }>(
+                `/escrow/${escrowType}/resolve-dispute`,
+                payload,
+            );
+
+            this.logger.log(`Dispute resolved for refund on escrow ${contractId}`);
+            return response;
+        } catch (error: any) {
+            this.logger.error(`Failed to resolve dispute for refund on escrow ${contractId}:`, error);
             throw this.handleApiError(error);
         }
     }

--- a/apps/api/src/providers/trustless-work/trustless-work.config.ts
+++ b/apps/api/src/providers/trustless-work/trustless-work.config.ts
@@ -12,6 +12,9 @@ export class TrustlessWorkConfig {
     readonly webhookSecret: string;
     readonly timeout: number;
 
+    // Platform identity (wallet used as disputeResolver / platformAddress)
+    readonly platformUserId: string;
+
     // Stellar Configuration
     readonly stellarNetwork: 'testnet' | 'mainnet';
     readonly stellarHorizonUrl: string;
@@ -24,6 +27,9 @@ export class TrustlessWorkConfig {
         this.apiUrl = this.getEnv('TRUSTLESS_API_URL', 'https://api.trustlesswork.com/v1');
         this.webhookSecret = this.getRequiredEnv('TRUSTLESS_WEBHOOK_SECRET');
         this.timeout = parseInt(this.getEnv('TRUSTLESS_TIMEOUT_MS', '60000'), 10);
+
+        // Platform identity
+        this.platformUserId = this.getRequiredEnv('PLATFORM_USER_ID');
 
         // Stellar Configuration
         const network = this.getEnv('STELLAR_NETWORK', 'testnet');

--- a/docs/api/endpoints/release-refund.md
+++ b/docs/api/endpoints/release-refund.md
@@ -68,19 +68,23 @@ Content-Type: application/json
 
 ## POST /orders/{orderId}/resolution/refund
 
-Refunds escrow funds to the buyer. In crypto-native mode, this calls the TW refund endpoint and signs with the buyer's wallet.
+Refunds escrow funds to the buyer. In crypto-native mode, this executes a **2-step on-chain process** since Trustless Work has no direct refund endpoint:
+
+1. **Dispute escrow** -- Buyer disputes the contract (signed by buyer's wallet)
+2. **Resolve dispute** -- Platform resolves with 100% distribution back to buyer (signed by platform wallet as `disputeResolver`)
+
+> **Why 2 steps?** Trustless Work smart contracts enforce that `disputeResolver` cannot be the same address as the disputer. The Orchestrator uses a dedicated platform wallet (`PLATFORM_USER_ID`) as `disputeResolver`, separate from buyer and seller.
 
 ### Request
 
 ```http
 POST /api/v1/orders/ord_abc123/resolution/refund
-x-api-key: ohk_live_xxx
+Authorization: Bearer ohk_live_xxx
 Content-Type: application/json
 ```
 
 ```json
 {
-    "requestedBy": "usr_buyer123",
     "reason": "Service not delivered"
 }
 ```
@@ -98,6 +102,25 @@ Content-Type: application/json
     }
 }
 ```
+
+### What Happens Internally
+
+```
+1. Validate order is IN_PROGRESS with FUNDED escrow
+2. Get buyer and platform Stellar addresses
+3. Call TW: dispute-escrow (buyer signs XDR)
+4. Call TW: resolve-dispute with 100% to buyer (platform signs XDR as disputeResolver)
+5. Credit buyer's internal balance
+6. Transition order: REFUND_REQUESTED -> CLOSED
+7. Emit events: order.refund_requested, order.refunded, order.closed
+```
+
+### Signer Roles (Refund)
+
+| Transaction | Signer | TW Role |
+|-------------|--------|---------|
+| dispute-escrow | Buyer | approver (the disputer) |
+| resolve-dispute | Platform | disputeResolver |
 
 ### Emitted Events
 

--- a/docs/architecture/flow-of-funds.md
+++ b/docs/architecture/flow-of-funds.md
@@ -159,18 +159,26 @@ flowchart TD
 2. `approveMilestone` -- **Buyer** (approver role)
 3. `releaseFunds` -- **Buyer** (releaseSigner role)
 
-#### Phase 4b: Refund (Return to Buyer)
+#### Phase 4b: Refund (Return to Buyer) -- 2-Step Dispute+Resolve
+
+Trustless Work has no direct `/refund` endpoint. Refunds use a 2-step process: the buyer disputes, then the platform resolves with 100% back to buyer.
+
+> **Key constraint:** The `disputeResolver` role MUST differ from the disputer. The platform wallet serves as `disputeResolver`.
 
 ```mermaid
-flowchart LR
+flowchart TD
     A[Marketplace] -->|POST /refund| B[Orchestrator]
-    B -->|1. Refund| C[Trustless Work]
+    B -->|1. dispute-escrow| C[Trustless Work]
     C -->|unsigned XDR| B
-    B -->|sign with buyer wallet| B
+    B -->|sign with BUYER wallet| B
+    B -->|send-transaction| C
+    B -->|2. resolve-dispute 100% to buyer| C
+    C -->|unsigned XDR| B
+    B -->|sign with PLATFORM wallet| B
     B -->|send-transaction| C
     C -->|USDC to buyer| D[Stellar]
-    B -->|2. Buyer balance ++| B
-    B -->|3. CLOSED| A
+    B -->|3. Buyer balance ++| B
+    B -->|4. CLOSED| A
 ```
 
 #### Phase 4c: Dispute + Resolution

--- a/docs/crypto-native/escrow-lifecycle.md
+++ b/docs/crypto-native/escrow-lifecycle.md
@@ -92,6 +92,32 @@ sequenceDiagram
     ORC->>ORC: Seller balance += amount
     ORC->>ORC: Order = CLOSED
     ORC-->>MP: { status: CLOSED }
+
+    Note over MP,ST: 6. REFUND (alternative to release, 2-step process)
+    MP->>ORC: POST /orders/{id}/resolution/refund
+
+    rect rgb(255, 240, 240)
+        Note over ORC,ST: Step 6a: Dispute Escrow (buyer signs)
+        ORC->>TW: POST /escrow/.../dispute-escrow
+        TW-->>ORC: { unsignedTransaction }
+        ORC->>ORC: Sign with buyer wallet
+        ORC->>TW: POST /helper/send-transaction
+        TW->>ST: Flag escrow as disputed
+    end
+
+    rect rgb(255, 255, 240)
+        Note over ORC,ST: Step 6b: Resolve Dispute 100% to buyer (platform signs)
+        ORC->>TW: POST /escrow/.../resolve-dispute
+        TW-->>ORC: { unsignedTransaction }
+        ORC->>ORC: Sign with platform wallet (disputeResolver)
+        ORC->>TW: POST /helper/send-transaction
+        TW->>ST: Release USDC to buyer
+        ST-->>TW: confirmed
+    end
+
+    ORC->>ORC: Buyer balance += amount
+    ORC->>ORC: Order = CLOSED
+    ORC-->>MP: { status: CLOSED }
 ```
 
 ## Order State Transitions
@@ -209,14 +235,33 @@ POST /api/v1/orders/{id}/resolution/refund
 
 ```json
 {
-    "requestedBy": "usr_...",
     "reason": "Service not delivered"
 }
 ```
 
-Returns funds to buyer's balance.
+Trustless Work does **not** have a direct `/refund` endpoint. Refunds require a 2-step process:
+
+1. **Dispute escrow** -- Buyer disputes the contract (signed by buyer)
+2. **Resolve dispute** -- Platform resolves with 100% distribution to buyer (signed by platform as `disputeResolver`)
+
+This is why the escrow contract assigns the **platform wallet** as `disputeResolver` (not the buyer). TW enforces that the `disputeResolver` cannot be the same address as the disputer.
 
 **Response:** `{ status: "CLOSED" }`
+
+## Escrow Role Assignments
+
+When deploying an escrow contract, the Orchestrator assigns roles as follows:
+
+| TW Role | Assigned To | Purpose |
+|---------|-------------|---------|
+| `approver` | Buyer | Approves milestones |
+| `serviceProvider` | Seller | Delivers work, marks milestones |
+| `platformAddress` | Platform (`PLATFORM_USER_ID`) | Receives platform fees |
+| `releaseSigner` | Buyer | Authorizes fund release |
+| `disputeResolver` | Platform (`PLATFORM_USER_ID`) | Resolves disputes (must differ from disputer) |
+| `receiver` | Seller | Receives released funds |
+
+> **Important:** `disputeResolver` MUST be a different address from the buyer. If the buyer is the disputer and also the `disputeResolver`, the TW smart contract will reject the transaction with: `"The dispute resolver cannot dispute the escrow"`.
 
 ## Trustless Work API Endpoints Used
 
@@ -227,7 +272,8 @@ Returns funds to buyer's balance.
 | Mark milestone complete | `POST /escrow/single-release/change-milestone-status` | Seller |
 | Approve milestone | `POST /escrow/single-release/approve-milestone` | Buyer |
 | Release funds | `POST /escrow/single-release/release-funds` | Buyer |
-| Refund | `POST /escrow/single-release/refund` | Buyer |
+| Dispute escrow (refund step 1) | `POST /escrow/single-release/dispute-escrow` | Buyer |
+| Resolve dispute (refund step 2) | `POST /escrow/single-release/resolve-dispute` | Platform |
 | Submit signed tx | `POST /helper/send-transaction` | N/A |
 
 ## Amount Format
@@ -338,11 +384,53 @@ curl -s -X POST $BASE/orders/$ORDER/escrow -H "x-api-key: $API_KEY" | jq .
 # 4. Fund escrow
 curl -s -X POST $BASE/orders/$ORDER/escrow/fund -H "x-api-key: $API_KEY" | jq .
 
-# 5. Release
+# 5a. Release (pay seller)
 curl -s -X POST $BASE/orders/$ORDER/resolution/release \
   -H "Content-Type: application/json" \
   -H "x-api-key: $API_KEY" \
   -d '{"requestedBy": "usr_buyer", "reason": "Work completed"}' | jq .
+
+# 5b. OR Refund (return to buyer) -- 2-step: dispute + resolve
+curl -s -X POST $BASE/orders/$ORDER/resolution/refund \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $API_KEY" \
+  -d '{"reason": "Service not delivered"}' | jq .
+```
+
+## E2E Test Results (Stellar Testnet)
+
+### Release Flow -- Verified 2026-02-17
+
+| Step | Endpoint | Result |
+|------|----------|--------|
+| Create order | `POST /api/v1/orders` | `ORDER_CREATED` |
+| Reserve funds | `POST /orders/{id}/reserve` | `FUNDS_RESERVED` |
+| Create escrow | `POST /orders/{id}/escrow` | `ESCROW_FUNDING` |
+| Fund escrow | `POST /orders/{id}/escrow/fund` | `IN_PROGRESS` |
+| Release | `POST /orders/{id}/resolution/release` | `CLOSED` |
+
+### Refund Flow -- Verified 2026-02-17
+
+| Step | Endpoint | Result |
+|------|----------|--------|
+| Create order | `POST /api/v1/orders` | `ORDER_CREATED` |
+| Reserve funds | `POST /orders/{id}/reserve` | `FUNDS_RESERVED` |
+| Create escrow | `POST /orders/{id}/escrow` | `ESCROW_FUNDING` (contract: `CBL3SW...`) |
+| Fund escrow | `POST /orders/{id}/escrow/fund` | `IN_PROGRESS` (escrow: `FUNDED`) |
+| Refund | `POST /orders/{id}/resolution/refund` | `CLOSED` (dispute + resolve-dispute) |
+
+**Test data:**
+- Order: `ord_pQ85Prp0TPhyHK9JejuwDP8xsoGyf1Og`
+- Contract: `CBL3SWJMMSE3KPIQDZJ7R4VDNWL3E6PWPBVOPSJTYKEW2GP2NYJWLHVE`
+- Buyer wallet: `GCV24WNJYX6QC3RX7QBB5GYE66YRDJPU6A4RKMRS33CDDTMWLQDA7Y27`
+- Platform wallet (disputeResolver): `GDGLXLBOS4DQYDIC3XAHUXXWWEB4OFPFHG2D2KL6AHTZ6W3KC2VTZW4J`
+
+### Unit Tests -- All Passing
+
+```
+Test Suites: 17 passed, 17 total
+Tests:       154 passed, 154 total
+Time:        7.504 s
 ```
 
 ## Related Documentation

--- a/docs/deployment/env-variables.md
+++ b/docs/deployment/env-variables.md
@@ -176,6 +176,7 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 | `TRUSTLESS_API_KEY` | Yes | `tw_xxx` | Trustless Work API key |
 | `TRUSTLESS_WEBHOOK_SECRET` | Recommended | `tws_xxx` | HMAC secret for webhook verification |
 | `TRUSTLESS_API_URL` | No | Auto | Override API base URL |
+| `PLATFORM_USER_ID` | Yes | `usr_xxx` | Platform user ID whose wallet is used as `disputeResolver` and `platformAddress` in escrow contracts |
 
 ### Getting Credentials
 
@@ -337,6 +338,9 @@ WALLET_ENCRYPTION_KEY=           # Generate: node -e "console.log(require('crypt
 # Trustless Work
 TRUSTLESS_API_KEY=
 TRUSTLESS_WEBHOOK_SECRET=
+
+# Platform Identity (wallet used as disputeResolver and platformAddress in escrow)
+PLATFORM_USER_ID=
 
 # Stellar
 STELLAR_NETWORK=testnet


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 

- fix(escrow): implement platform wallet for refund flow via dispute+resolve

## 🛠️ Issue

- Closes #76

## 📚 Description

Trustless Work has no direct `/refund` endpoint. Refunds require a **2-step on-chain process**:

1. **`dispute-escrow`** — Buyer disputes the contract (signed by buyer)
2. **`resolve-dispute`** — Platform resolves with 100% distribution to buyer (signed by platform as `disputeResolver`)

The TW smart contract enforces that the `disputeResolver` role **cannot be the same address** as the disputer. Previously, the buyer was set as `disputeResolver`, causing the error: *"The dispute resolver cannot dispute the escrow"*.

**Solution:** Add a dedicated **platform wallet** (`PLATFORM_USER_ID`) that serves as both `platformAddress` and `disputeResolver` in escrow contracts, separate from buyer and seller.

## ✅ Changes applied

### Code Changes
- **`trustless-work.config.ts`** — Added `platformUserId` config from `PLATFORM_USER_ID` env var
- **`escrow.client.ts`** — Updated `createEscrow()` to accept `platformAddress` for roles (`platformAddress`, `disputeResolver`); updated `resolveDisputeForRefund()` to accept separate `disputeResolverAddress` and `buyerAddress`; cleaned dead imports
- **`orders.service.ts`** — Injected `TrustlessWorkConfig`; fetches platform wallet via `getDepositInfo(twConfig.platformUserId)` and passes `platformAddress` to escrow creation
- **`resolution.service.ts`** — Injected `TrustlessWorkConfig`; updated `requestRefund()` step 2 to use platform wallet for resolve-dispute signing; replaced dead `refundEscrow()` call in `executeFullRefund()` with 2-step dispute+resolve flow
- **`orders.service.spec.ts`** — Added `TrustlessWorkConfig` mock
- **`.env.example`** — Added `PLATFORM_USER_ID` placeholder

### Documentation Updates
- **`docs/crypto-native/escrow-lifecycle.md`** — Added refund flow to mermaid diagram, escrow role assignments table, TW API endpoints table, E2E test results
- **`docs/api/endpoints/release-refund.md`** — Rewrote refund endpoint docs with 2-step process, internal flow, and signer roles
- **`docs/architecture/flow-of-funds.md`** — Updated Phase 4b refund diagram with dispute+resolve flow
- **`docs/deployment/env-variables.md`** — Added `PLATFORM_USER_ID` env var documentation

## 🔍 Evidence/Media (screenshots/videos)

### E2E Test — Refund Flow on Stellar Testnet (2026-02-17)

| Step | Endpoint | Status |
|------|----------|--------|
| 1. Create order | `POST /api/v1/orders` | ✅ `ORDER_CREATED` |
| 2. Reserve funds | `POST /orders/{id}/reserve` | ✅ `FUNDS_RESERVED` |
| 3. Create escrow | `POST /orders/{id}/escrow` | ✅ `ESCROW_FUNDING` (contract: `CBL3SW...`) |
| 4. Fund escrow | `POST /orders/{id}/escrow/fund` | ✅ `IN_PROGRESS` (escrow: `FUNDED`) |
| 5. Refund | `POST /orders/{id}/resolution/refund` | ✅ `CLOSED` (dispute + resolve) |

**Test data:**
- Order: `ord_pQ85Prp0TPhyHK9JejuwDP8xsoGyf1Og`
- Contract: `CBL3SWJMMSE3KPIQDZJ7R4VDNWL3E6PWPBVOPSJTYKEW2GP2NYJWLHVE`
- Buyer: `GCV24WNJYX6QC3RX7QBB5GYE66YRDJPU6A4RKMRS33CDDTMWLQDA7Y27`
- Platform (disputeResolver): `GDGLXLBOS4DQYDIC3XAHUXXWWEB4OFPFHG2D2KL6AHTZ6W3KC2VTZW4J`

### Unit Tests — All Passing

```
Test Suites: 17 passed, 17 total
Tests:       154 passed, 154 total
Time:        7.504 s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)