### PR TITLE
fix(resolution): fix 4 bugs in dispute SPLIT resolution flow

### DIFF
--- a/apps/api/src/modules/resolution/resolution.service.ts
+++ b/apps/api/src/modules/resolution/resolution.service.ts
@@ -1220,6 +1220,9 @@ export class ResolutionService {
 
     /**
      * Execute split resolution for dispute.
+     * Uses the same 2-step TW pattern as refund:
+     *   Step 1: dispute-escrow (buyer signs)
+     *   Step 2: resolve-dispute with distributions to BOTH buyer and seller (platform signs)
      * @private
      */
     private async executeSplitResolution(
@@ -1233,16 +1236,24 @@ export class ResolutionService {
             `Executing split resolution for dispute ${dispute.id}: release=${releaseAmount}, refund=${refundAmount}`,
         );
 
-        // Calls escrowClient.resolveDispute() with split amounts + sign+send
         const escrowType =
             order.milestones && order.milestones.length > 1 ? 'multi-release' : 'single-release';
 
-        const disputeResult = await this.escrowClient.resolveDispute(
+        // Get buyer, seller, and platform wallet addresses
+        const [buyerDeposit, sellerDeposit, platformDeposit] = await Promise.all([
+            this.paymentProvider.getDepositInfo(order.buyerId),
+            this.paymentProvider.getDepositInfo(order.sellerId),
+            this.paymentProvider.getDepositInfo(this.twConfig.platformUserId),
+        ]);
+        const buyerAddress = buyerDeposit.address!;
+        const sellerAddress = sellerDeposit.address!;
+        const platformAddress = platformDeposit.address!;
+
+        // Step 1: Dispute the escrow (buyer signs — any party except disputeResolver can dispute)
+        this.logger.debug(`Split step 1/2: Disputing escrow for order ${order.id}`);
+        const disputeResult = await this.escrowClient.disputeEscrow(
             order.escrow!.trustlessContractId!,
-            {
-                release_amount: releaseAmount,
-                refund_amount: refundAmount,
-            },
+            buyerAddress,
             escrowType,
         );
 
@@ -1252,6 +1263,28 @@ export class ResolutionService {
                 disputeResult.unsignedTransaction,
             );
             await this.escrowClient.sendTransaction(signedXdr);
+            this.logger.log(`Split step 1/2: Escrow disputed for order ${order.id}`);
+        }
+
+        // Step 2: Resolve dispute with distributions to both buyer and seller (platform signs as disputeResolver)
+        this.logger.debug(`Split step 2/2: Resolving dispute with split for order ${order.id}`);
+        const resolveResult = await this.escrowClient.resolveDisputeWithSplit(
+            order.escrow!.trustlessContractId!,
+            platformAddress,
+            [
+                { address: sellerAddress, amount: parseFloat(releaseAmount) },
+                { address: buyerAddress, amount: parseFloat(refundAmount) },
+            ],
+            escrowType,
+        );
+
+        if (resolveResult.unsignedTransaction) {
+            const signedXdr = await this.paymentProvider.signEscrowTransaction(
+                this.twConfig.platformUserId, // Platform signs as disputeResolver
+                resolveResult.unsignedTransaction,
+            );
+            await this.escrowClient.sendTransaction(signedXdr);
+            this.logger.log(`Split step 2/2: Dispute resolved with split for order ${order.id}`);
         }
 
         // Credit seller via creditAvailable

--- a/apps/api/src/providers/trustless-work/clients/escrow.client.ts
+++ b/apps/api/src/providers/trustless-work/clients/escrow.client.ts
@@ -8,8 +8,7 @@ import {
     TrustlessReleaseResult,
 } from '../types/trustless-work.types';
 import { CreateEscrowDto } from '../dto/escrow.dto';
-import { DisputeResolutionDto } from '../dto/dispute-resolution.dto';
-import { orchestratorToStellar, toStroops, ERROR_CODES } from '@offerhub/shared';
+import { ERROR_CODES } from '@offerhub/shared';
 import Big from 'big.js';
 
 /**
@@ -409,36 +408,40 @@ export class EscrowClient {
     }
 
     /**
-     * Resolve dispute with split decision
-     * Uses /escrow/{type}/resolve-dispute endpoint
+     * Resolve dispute with split decision (distributions to multiple parties).
+     * Uses /escrow/{type}/resolve-dispute endpoint.
+     * TW expects: { contractId, disputeResolver, distributions: [{address, amount}] }
+     * Amounts must be in USDC (not stroops) — TW converts internally.
+     *
+     * @param contractId Escrow contract ID
+     * @param disputeResolverAddress Platform wallet address (must match escrow's disputeResolver role)
+     * @param distributions Array of {address, amount} for each party (buyer + seller)
+     * @param escrowType single-release or multi-release
      */
-    async resolveDispute(
+    async resolveDisputeWithSplit(
         contractId: string,
-        resolution: DisputeResolutionDto,
+        disputeResolverAddress: string,
+        distributions: Array<{ address: string; amount: number }>,
         escrowType: 'single-release' | 'multi-release' = 'single-release',
-    ): Promise<{ success: boolean; unsignedTransaction?: string; transaction_hash?: string }> {
+    ): Promise<{ unsignedTransaction?: string; transaction_hash?: string }> {
         try {
-            this.logger.debug(`Resolving dispute for escrow: ${contractId}`, resolution);
-
-            // Convert amounts to stroops
-            const releaseAmountStroops = toStroops(
-                orchestratorToStellar(resolution.release_amount),
+            this.logger.debug(
+                `Resolving dispute with split for escrow: ${contractId}, distributions: ${JSON.stringify(distributions)}`,
             );
-            const refundAmountStroops = toStroops(orchestratorToStellar(resolution.refund_amount));
 
             const payload = {
                 contractId,
-                releaseAmount: releaseAmountStroops,
-                refundAmount: refundAmountStroops,
+                disputeResolver: disputeResolverAddress,
+                distributions,
             };
 
-            const response = await this.post<{ success: boolean; unsignedTransaction?: string; transaction_hash?: string }>(
+            const response = await this.post<{ unsignedTransaction?: string; transaction_hash?: string }>(
                 `/escrow/${escrowType}/resolve-dispute`,
                 payload,
             );
 
             this.logger.log(
-                `Dispute resolved for escrow ${contractId}. Tx: ${response.transaction_hash}`,
+                `Dispute resolved with split for escrow ${contractId}. Tx: ${response.transaction_hash}`,
             );
 
             return response;

--- a/docs/api/endpoints/release-refund.md
+++ b/docs/api/endpoints/release-refund.md
@@ -171,6 +171,94 @@ Content-Type: application/json
 
 ---
 
+## POST /disputes/{disputeId}/resolve (SPLIT Decision)
+
+Resolves a dispute by splitting escrow funds between buyer and seller. Uses the same 2-step on-chain process as refund, but with **distributions to both parties** instead of 100% to one.
+
+1. **Dispute escrow** -- Buyer disputes the contract (signed by buyer's wallet)
+2. **Resolve dispute with distributions** -- Platform resolves with split amounts to buyer AND seller (signed by platform wallet as `disputeResolver`)
+
+### Request
+
+```http
+POST /api/v1/disputes/dsp_xxx/resolve
+x-api-key: ohk_live_xxx
+Content-Type: application/json
+```
+
+```json
+{
+    "decision": "SPLIT",
+    "release_amount": "6.00",
+    "refund_amount": "4.00",
+    "note": "Partial delivery — 60% work completed"
+}
+```
+
+> **Validation:** `release_amount + refund_amount` must equal the order's total `amount`.
+
+### Response
+
+```json
+{
+    "data": {
+        "success": true,
+        "data": {
+            "id": "dsp_xxx",
+            "status": "RESOLVED",
+            "resolutionDecision": "SPLIT",
+            "order": {
+                "id": "ord_xxx",
+                "status": "CLOSED"
+            },
+            "escrow": {
+                "status": "RELEASED",
+                "releasedAt": "2026-02-17T19:19:39.605Z"
+            }
+        }
+    }
+}
+```
+
+### What Happens Internally
+
+```
+1. Validate dispute is UNDER_REVIEW with IN_PROGRESS order
+2. Validate release_amount + refund_amount == order.amount
+3. Get buyer, seller, and platform Stellar addresses
+4. Call TW: dispute-escrow (buyer signs XDR)
+5. Call TW: resolve-dispute with distributions (platform signs XDR)
+   → distributions: [{seller, releaseAmount}, {buyer, refundAmount}]
+6. Credit seller's internal balance with release_amount
+7. Credit buyer's internal balance with refund_amount
+8. Transition: dispute RESOLVED, order CLOSED, escrow RELEASED
+9. Emit event: DISPUTE_RESOLVED (decision: SPLIT)
+```
+
+### Signer Roles (SPLIT)
+
+| Transaction | Signer | TW Role |
+|-------------|--------|---------|
+| dispute-escrow | Buyer | approver (the disputer) |
+| resolve-dispute | Platform | disputeResolver |
+
+### TW API Payload (resolve-dispute with distributions)
+
+```json
+{
+    "contractId": "CAKRHV...",
+    "disputeResolver": "GDGLXL...",
+    "distributions": [
+        { "address": "GDWXCM...", "amount": 6 },
+        { "address": "GCV24W...", "amount": 4 }
+    ]
+}
+```
+
+> **Note:** Amounts are in USDC (not stroops). TW converts internally.
+
+---
+
 ## Important Notes
 
 ### Crypto-Native Release Process

--- a/docs/architecture/flow-of-funds.md
+++ b/docs/architecture/flow-of-funds.md
@@ -181,19 +181,38 @@ flowchart TD
     B -->|4. CLOSED| A
 ```
 
-#### Phase 4c: Dispute + Resolution
+#### Phase 4c: Dispute + SPLIT Resolution (2 On-Chain Transactions)
+
+When a dispute is resolved with a SPLIT decision, funds are distributed to **both** buyer and seller according to the arbitrator's decision.
 
 ```mermaid
-flowchart LR
-    A[Buyer/Seller] -->|1. Open dispute| B[Marketplace]
-    B -->|2. POST /disputes| C[Orchestrator]
-    C -->|3. Freeze order| C
-    E[Support] -->|4. Review case| C
-    E -->|5. POST /resolve| C
-    C -->|6. Release/Refund/Split| D[Trustless Work]
-    D -->|7. Execute on-chain| F[Stellar]
-    C -->|8. Distribute balances| C
+flowchart TD
+    A[Support] -->|POST /disputes/id/resolve| B[Orchestrator]
+    B -->|"decision: SPLIT, release: $6, refund: $4"| B
+    B -->|1. dispute-escrow| C[Trustless Work]
+    C -->|unsigned XDR| B
+    B -->|sign with BUYER wallet| B
+    B -->|send-transaction| C
+    B -->|"2. resolve-dispute<br/>distributions: [{seller,$6},{buyer,$4}]"| C
+    C -->|unsigned XDR| B
+    B -->|sign with PLATFORM wallet| B
+    B -->|send-transaction| C
+    C -->|USDC split on-chain| D[Stellar]
+    B -->|3. Seller balance += $6| B
+    B -->|4. Buyer balance += $4| B
+    B -->|5. CLOSED| A
 ```
+
+**Money flow (SPLIT):**
+- Smart contract distributes USDC to both seller and buyer wallets
+- Orchestrator credits both internal balances
+- Order transitions to CLOSED, dispute to RESOLVED
+
+**Transaction signers:**
+1. `dispute-escrow` -- **Buyer** (approver role, the disputer)
+2. `resolve-dispute` -- **Platform** (disputeResolver role)
+
+> **Note:** The same 2-step on-chain process is used for refund (100% to buyer) and SPLIT (custom distribution to both). The only difference is the `distributions` array in the resolve-dispute payload.
 
 ---
 
@@ -272,6 +291,7 @@ sequenceDiagram
 | Fund escrow | 0.00 | -80.00 | +80.00 |
 | **After release** | **20.00** | **0.00** | **0.00** |
 | **After refund** | **100.00** | **0.00** | **0.00** |
+| **After SPLIT ($40 refund)** | **60.00** | **0.00** | **0.00** |
 
 ### Seller Balance
 

--- a/docs/crypto-native/escrow-lifecycle.md
+++ b/docs/crypto-native/escrow-lifecycle.md
@@ -118,6 +118,34 @@ sequenceDiagram
     ORC->>ORC: Buyer balance += amount
     ORC->>ORC: Order = CLOSED
     ORC-->>MP: { status: CLOSED }
+
+    Note over MP,ST: 7. SPLIT RESOLUTION (dispute → distribute to both parties)
+    MP->>ORC: POST /disputes/{id}/resolve (decision: SPLIT)
+
+    rect rgb(255, 240, 240)
+        Note over ORC,ST: Step 7a: Dispute Escrow (buyer signs)
+        ORC->>TW: POST /escrow/.../dispute-escrow
+        TW-->>ORC: { unsignedTransaction }
+        ORC->>ORC: Sign with buyer wallet
+        ORC->>TW: POST /helper/send-transaction
+        TW->>ST: Flag escrow as disputed
+    end
+
+    rect rgb(240, 240, 255)
+        Note over ORC,ST: Step 7b: Resolve Dispute with split distributions (platform signs)
+        ORC->>TW: POST /escrow/.../resolve-dispute
+        Note right of ORC: distributions: [{seller, $X}, {buyer, $Y}]
+        TW-->>ORC: { unsignedTransaction }
+        ORC->>ORC: Sign with platform wallet (disputeResolver)
+        ORC->>TW: POST /helper/send-transaction
+        TW->>ST: Distribute USDC to both parties
+        ST-->>TW: confirmed
+    end
+
+    ORC->>ORC: Seller balance += releaseAmount
+    ORC->>ORC: Buyer balance += refundAmount
+    ORC->>ORC: Order = CLOSED
+    ORC-->>MP: { status: CLOSED }
 ```
 
 ## Order State Transitions
@@ -274,6 +302,8 @@ When deploying an escrow contract, the Orchestrator assigns roles as follows:
 | Release funds | `POST /escrow/single-release/release-funds` | Buyer |
 | Dispute escrow (refund step 1) | `POST /escrow/single-release/dispute-escrow` | Buyer |
 | Resolve dispute (refund step 2) | `POST /escrow/single-release/resolve-dispute` | Platform |
+| Dispute escrow (split step 1) | `POST /escrow/single-release/dispute-escrow` | Buyer |
+| Resolve dispute with split (split step 2) | `POST /escrow/single-release/resolve-dispute` | Platform |
 | Submit signed tx | `POST /helper/send-transaction` | N/A |
 
 ## Amount Format
@@ -423,6 +453,29 @@ curl -s -X POST $BASE/orders/$ORDER/resolution/refund \
 - Order: `ord_pQ85Prp0TPhyHK9JejuwDP8xsoGyf1Og`
 - Contract: `CBL3SWJMMSE3KPIQDZJ7R4VDNWL3E6PWPBVOPSJTYKEW2GP2NYJWLHVE`
 - Buyer wallet: `GCV24WNJYX6QC3RX7QBB5GYE66YRDJPU6A4RKMRS33CDDTMWLQDA7Y27`
+- Platform wallet (disputeResolver): `GDGLXLBOS4DQYDIC3XAHUXXWWEB4OFPFHG2D2KL6AHTZ6W3KC2VTZW4J`
+
+### Dispute → SPLIT Resolution Flow -- Verified 2026-02-17
+
+| Step | Endpoint | Result |
+|------|----------|--------|
+| Create order | `POST /api/v1/orders` | `ORDER_CREATED` |
+| Reserve funds | `POST /orders/{id}/reserve` | `FUNDS_RESERVED` |
+| Create escrow | `POST /orders/{id}/escrow` | `ESCROW_FUNDING` (contract: `CAKRHV...`) |
+| Fund escrow | `POST /orders/{id}/escrow/fund` | `IN_PROGRESS` (escrow: `FUNDED`) |
+| Open dispute | `POST /api/v1/disputes` | `OPEN` (openedBy: `BUYER`) |
+| Assign dispute | `POST /disputes/{id}/assign` | `UNDER_REVIEW` |
+| Resolve SPLIT | `POST /disputes/{id}/resolve` | `RESOLVED` (decision: `SPLIT`) |
+| **Final state** | -- | Order: `CLOSED`, Escrow: `RELEASED` |
+
+**Split details:** $6.00 to seller + $4.00 refund to buyer (from $10.00 total)
+
+**Test data:**
+- Order: `ord_hvfMNSBGzdiFDzS89qZMmAz06sMU8BJs`
+- Dispute: `dsp_VbusoJ8bzdOwncUjKvGKQS79YnA6RF0G`
+- Contract: `CAKRHVIA7KKNXVC5XDSWIKDAF4HDMDJJ2B6DNUYUTQEPUJP5YN7E5YH3`
+- Buyer wallet: `GCV24WNJYX6QC3RX7QBB5GYE66YRDJPU6A4RKMRS33CDDTMWLQDA7Y27`
+- Seller wallet: `GDWXCMZTP6DVDBJY54NSNPH4CBOEUMVRMSY2XRG4VBSDYORMHJK4QOC3`
 - Platform wallet (disputeResolver): `GDGLXLBOS4DQYDIC3XAHUXXWWEB4OFPFHG2D2KL6AHTZ6W3KC2VTZW4J`
 
 ### Unit Tests -- All Passing


### PR DESCRIPTION
## 🔧 Title:

fix(resolution): fix 4 bugs in dispute SPLIT resolution flow

## 🛠️ Issue

- Closes #90

## 📚 Description

The dispute → SPLIT resolution flow had 4 bugs preventing it from working with Trustless Work on Stellar. This PR fixes all 4 and includes E2E verification on testnet.

## ✅ Changes applied

### Code fixes (`escrow.client.ts`)
- **Bug 1**: Changed `resolveDispute()` payload from `{contractId, releaseAmount, refundAmount}` to `{contractId, disputeResolver, distributions: [{address, amount}]}` —PI spec
- **Bug 4**: Amounts now sent as USDC numbers (e.g., `6`) instead of stroops (e.g., `60000000`)
- Renamed method to `resolveDisputeWithSplit()` for clarity

### Code fixes (`resolution.service.ts`)
- **Bug 2**: Added missing `disputeEscrow()` step before `resolveDisputeWithSplit()` (buyer signs)
- **Bug 3**: Platform wallet now signs resolve-dispute (as `disputeResolver`), not buyer
- Gets 3 wallet addresses (buyer, seller, platform) for the 2-step flow
- Credits both seller (releaseAmount) and buyer (refundAmount) balances

### Documentation
- `escrow-lifecycle.md`: Added SPLIT flow diagram (section 7), TW endpoints table, E2E test results
- `release-refund.md`: Added SPLIT resolution endpoint docs with payload example
- `flow-of-funds.md`: Expanded Phase 4c with SPLIT-specific flowchart and balance table

## 🔍 Evidence/Media

### E2E Test Results (Stellar Testnet — 2026-02-17)

| Step | Result |
|------|--------|
| Create order | `ORDER_CREATED` |
| Reserve | `FUNDS_RESERVED` |
| Create escro`ESCROW_FUNDING` |
| Fund escrow | `IN_PROGRESS` (FUNDED) |
| Open dispute | `OPEN` (BUYER) |
| Assign dispute | `UNDER_REVIEW` |
| **Resolve SPLIT** | **RESOLVED** → Order CLOSED, Escrow RELEASED |

**Split:** $6.00 to seller + $4.00 to buyer (from $10.00 total)

- Contract: `CAKRHVIA7KKNXVC5XDSWIKDAF4HDMDJJ2B6DNUYUTQEPUJP5YN7E5YH3`
- 154 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)