### PR TITLE
test(cancel): E2E verify cancel order flow

### DIFF
--- a/docs/crypto-native/escrow-lifecycle.md
+++ b/docs/crypto-native/escrow-lifecycle.md
@@ -429,6 +429,16 @@ curl -s -X POST $BASE/orders/$ORDER/resolution/refund \
 
 ## E2E Test Results (Stellar Testnet)
 
+### Cancel Order Flow -- Verified 2026-02-18
+
+| Test | Endpoint | Result |
+|------|----------|--------|
+| Cancel from ORDER_CREATED | `POST /orders/{id}/cancel` | `CLOSED` (no balance change) |
+| Cancel from FUNDS_RESERVED | `POST /orders/{id}/cancel` | `CLOSED` (buyer balance restored) |
+| Cancel from ESCROW_FUNDING | `POST /orders/{id}/cancel` | `INVALID_STATE` (rejected) ✅ |
+
+**Note:** Cancel is only allowed from `ORDER_CREATED` or `FUNDS_RESERVED` states. Once escrow is initiated, the order cannot be cancelled.
+
 ### Release Flow -- Verified 2026-02-17
 
 | Step | Endpoint | Result |


### PR DESCRIPTION
## 🔧 Title:

test(cancel): E2E verify cancel order flow

## 🛠️ Issue

- Closes #87

## 📚 Description

E2E verification of the cancel order flow on Stellar testnet. No code changes were required — the flow was already implemented correctly.

## ✅ Changes applied

- `docs/crypto-native/escrow-lifecycle.md`: Added Cancel Order Flow E2E test results section

## 🔍 Evidence/Media

### E2E Test Results (2026-02-18)

| Test | Endpoint | Result |
|------|----------|--------|
| Cancel from ORDER_CREATED | `POST /orders/{id}/cancel` | `CLOSED` ✅ |
| Cancel from FUNDS_RESERVED | `POST /orders/{id}/cancel` | `CLOSED` + balance restored ✅ |
| Cancel from ESCROW_FUNDING | `POST /orders/{id}/cancel` | `INVALID_STATE` (rejected) ✅ |

**Key behavior verified:**
- No blockchain transactions involved (purely internal balance operation)
- `cancelReservation()` correctly restores buyer balance when cancelling from `FUNDS_RESERVED`
- State machine correctly rejects cancel from `ESCROW_FUNDING` and later states

🤖 Generated with [Claude Code](https://claude.com/claude-code)