### PR TITLE
test(dispute): E2E verify dispute FULL_REFUND resolution flow

### DIFF
--- a/docs/crypto-native/escrow-lifecycle.md
+++ b/docs/crypto-native/escrow-lifecycle.md
@@ -489,6 +489,28 @@ curl -s -X POST $BASE/orders/$ORDER/resolution/refund \
 - Buyer wallet: `GCV24WNJYX6QC3RX7QBB5GYE66YRDJPU6A4RKMRS33CDDTMWLQDA7Y27`
 - Seller wallet: `GDWXCMZTP6DVDBJY54NSNPH4CBOEUMVRMSY2XRG4VBSDYORMHJK4QOC3`
 
+### Dispute → FULL_REFUND Resolution Flow -- Verified 2026-02-18
+
+| Step | Endpoint | Result |
+|------|----------|--------|
+| Create order | `POST /api/v1/orders` | `ORDER_CREATED` |
+| Reserve funds | `POST /orders/{id}/reserve` | `FUNDS_RESERVED` |
+| Create escrow | `POST /orders/{id}/escrow` | `ESCROW_FUNDING` (contract: `CDAEJ3...`) |
+| Fund escrow | `POST /orders/{id}/escrow/fund` | `IN_PROGRESS` (escrow: `FUNDED`) |
+| Open dispute | `POST /orders/{id}/resolution/dispute` | `OPEN` (dispute: `dsp_zWAF...`) |
+| Assign dispute | `POST /disputes/{id}/assign` | `UNDER_REVIEW` |
+| Resolve FULL_REFUND | `POST /disputes/{id}/resolve` | `RESOLVED` (decision: `FULL_REFUND`) |
+| **Final state** | -- | Order: `CLOSED`, Dispute: `RESOLVED` |
+
+**Full refund:** 100% ($2.00) returned to buyer via FULL_REFUND decision.
+
+**Test data:**
+- Order: `ord_PVTgqAMDqI8v1oOLdcozzqmnWQXNzpCK`
+- Dispute: `dsp_zWAFVtrXWPOlUru2NYWkxRkGfIaf1LGk`
+- Contract: `CDAEJ3DS2ZF5ZXBPBGZX7C6VTID5237Z3MUCQFKTKGULDXOUWS4FDNJR`
+- Buyer wallet: `GCV24WNJYX6QC3RX7QBB5GYE66YRDJPU6A4RKMRS33CDDTMWLQDA7Y27`
+- Platform wallet (disputeResolver): `GDGLXLBOS4DQYDIC3XAHUXXWWEB4OFPFHG2D2KL6AHTZ6W3KC2VTZW4J`
+
 ### Dispute → SPLIT Resolution Flow -- Verified 2026-02-17
 
 | Step | Endpoint | Result |


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 
test(dispute): E2E verify dispute FULL_REFUND resolution flow

## 🛠️ Issue

- Closes #89

## 📚 Description

E2E verification of the Dispute → FULL_REFUND resolution flow on Stellar testnet. This completes the verification of all three dispute resolution types: SPLIT, FULL_RELEASE, and FULL_REFUND.

## ✅ Changes applied

- **`docs/crypto-native/escrow-lifecycle.md`**: Added FULL_REFUND dispute resolution test results section with full test data

## 🔍 Evidence/Media (screenshots/videos)

```
Order: ord_PVTgqAMDqI8v1oOLdcozzqmnWQXNzpCK ($2.00)
Contract: CDAEJ3DS2ZF5ZXBPBGZX7C6VTID5237Z3MUCQFKTKGULDXOUWS4FDNJR

Steps verified:
✅ Create order          → ORDER_CREATED
✅ Reserve funds         → FUNDS_RESERVED
✅ Create escrow         → ESCROW_FUNDING (CDAEJ3...)
✅ Fund escrow           → IN_PROGRESS
✅ Open dispute          → OPEN (dsp_zWAFVtrXWPOlUru2NYWkxRkGfIaf1LGk)
✅ Assign dispute        → UNDER_REVIEW
✅ Resolve FULL_REFUND   → RESOLVED (decision: FULL_REFUND)
✅ Final order state     → CLOSED

All dispute resolution types now verified on Stellar testnet:
- SPLIT       ✅ PR #91
- FULL_RELEASE ✅ PR #93
- FULL_REFUND  ✅ This PR
```